### PR TITLE
feat: OpenRouter と Ollama アダプターを追加

### DIFF
--- a/adapters/ollama.py
+++ b/adapters/ollama.py
@@ -1,0 +1,61 @@
+from typing import AsyncGenerator
+
+import httpx
+
+from .base import AbstractLLMAdapter, ProviderError, ProviderTimeoutError
+
+
+class OllamaAdapter(AbstractLLMAdapter):
+    """Ollama ローカルインスタンス用アダプター（OpenAI 互換エンドポイント使用）"""
+
+    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+        self._base_url = base_url.rstrip("/")
+
+    def _headers(self) -> dict:
+        return {"Content-Type": "application/json"}
+
+    async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
+        body = {**payload, "model": model, "stream": False}
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(
+                    f"{self._base_url}/v1/chat/completions",
+                    headers=self._headers(),
+                    json=body,
+                )
+        except httpx.TimeoutException as exc:
+            raise ProviderTimeoutError(f"Ollama timeout ({model})") from exc
+        except httpx.ConnectError as exc:
+            raise ProviderError(f"Ollama connection failed: {exc}") from exc
+
+        if not resp.is_success:
+            raise ProviderError(f"Ollama {resp.status_code} ({model}): {resp.text[:200]}")
+        return resp.json()
+
+    async def chat_completion_stream(
+        self, payload: dict, model: str, timeout: float
+    ) -> AsyncGenerator[bytes, None]:
+        body = {**payload, "model": model, "stream": True}
+        client = httpx.AsyncClient(timeout=timeout)
+        try:
+            req = client.build_request(
+                "POST",
+                f"{self._base_url}/v1/chat/completions",
+                headers=self._headers(),
+                json=body,
+            )
+            resp = await client.send(req, stream=True)
+
+            if not resp.is_success:
+                err = await resp.aread()
+                raise ProviderError(f"Ollama {resp.status_code} ({model}): {err[:200]}")
+
+            async for chunk in resp.aiter_bytes():
+                if chunk:
+                    yield chunk
+        except httpx.TimeoutException as exc:
+            raise ProviderTimeoutError(f"Ollama timeout ({model})") from exc
+        except httpx.ConnectError as exc:
+            raise ProviderError(f"Ollama connection failed: {exc}") from exc
+        finally:
+            await client.aclose()

--- a/adapters/openrouter.py
+++ b/adapters/openrouter.py
@@ -1,0 +1,68 @@
+from typing import AsyncGenerator
+
+import httpx
+
+from .base import AbstractLLMAdapter, ProviderError, ProviderTimeoutError, RateLimitError
+
+
+class OpenRouterAdapter(AbstractLLMAdapter):
+    """OpenRouter API アダプター"""
+
+    def __init__(self, api_key: str, base_url: str = "https://openrouter.ai/api/v1") -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "http://localhost",
+            "X-Title": "openrouter-routing",
+        }
+
+    async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
+        body = {**payload, "model": model, "stream": False}
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(
+                    f"{self._base_url}/chat/completions",
+                    headers=self._headers(),
+                    json=body,
+                )
+        except httpx.TimeoutException as exc:
+            raise ProviderTimeoutError(f"OpenRouter timeout ({model})") from exc
+
+        if resp.status_code == 429:
+            raise RateLimitError(f"OpenRouter 429 ({model})")
+        if not resp.is_success:
+            raise ProviderError(f"OpenRouter {resp.status_code} ({model}): {resp.text[:200]}")
+        return resp.json()
+
+    async def chat_completion_stream(
+        self, payload: dict, model: str, timeout: float
+    ) -> AsyncGenerator[bytes, None]:
+        body = {**payload, "model": model, "stream": True}
+        client = httpx.AsyncClient(timeout=timeout)
+        try:
+            req = client.build_request(
+                "POST",
+                f"{self._base_url}/chat/completions",
+                headers=self._headers(),
+                json=body,
+            )
+            resp = await client.send(req, stream=True)
+
+            if resp.status_code == 429:
+                await resp.aclose()
+                raise RateLimitError(f"OpenRouter 429 ({model})")
+            if not resp.is_success:
+                err = await resp.aread()
+                raise ProviderError(f"OpenRouter {resp.status_code} ({model}): {err[:200]}")
+
+            async for chunk in resp.aiter_bytes():
+                if chunk:
+                    yield chunk
+        except httpx.TimeoutException as exc:
+            raise ProviderTimeoutError(f"OpenRouter timeout ({model})") from exc
+        finally:
+            await client.aclose()

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,0 +1,167 @@
+import sys
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# base モジュールをモック化（PR1 未マージ時の対応）
+if 'adapters.base' not in sys.modules:
+    from abc import ABC, abstractmethod
+    from typing import AsyncIterator
+    from types import ModuleType
+    base_module = ModuleType('adapters.base')
+    
+    class ProviderTimeoutError(Exception):
+        pass
+    
+    class ProviderError(Exception):
+        pass
+    
+    class AbstractLLMAdapter(ABC):
+        @abstractmethod
+        async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
+            pass
+        
+        @abstractmethod
+        async def chat_completion_stream(self, payload: dict, model: str, timeout: float) -> AsyncIterator[bytes]:
+            pass
+    
+    base_module.ProviderTimeoutError = ProviderTimeoutError
+    base_module.ProviderError = ProviderError
+    base_module.AbstractLLMAdapter = AbstractLLMAdapter
+    sys.modules['adapters.base'] = base_module
+else:
+    from adapters.base import ProviderError, ProviderTimeoutError
+
+from adapters.ollama import OllamaAdapter
+
+
+class TestOllamaAdapter:
+    """OllamaAdapter のテスト"""
+
+    def test_initialization(self):
+        """初期化が正しく行われる"""
+        adapter = OllamaAdapter(base_url="http://localhost:11434/")
+        assert adapter._base_url == "http://localhost:11434"
+
+    def test_default_base_url(self):
+        """デフォルトの base_url が設定される"""
+        adapter = OllamaAdapter()
+        assert adapter._base_url == "http://localhost:11434"
+
+    def test_headers(self):
+        """ヘッダーが正しく生成される"""
+        adapter = OllamaAdapter()
+        headers = adapter._headers()
+        assert headers["Content-Type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_success(self):
+        """正常なレスポンスが返される"""
+        adapter = OllamaAdapter()
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.is_success = True
+        mock_response.json.return_value = {"result": "success"}
+        
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            
+            result = await adapter.chat_completion(
+                {"messages": [{"role": "user", "content": "test"}]},
+                "phi3.5:latest",
+                10.0
+            )
+            
+            assert result == {"result": "success"}
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_timeout(self):
+        """タイムアウト時に ProviderTimeoutError が raise される"""
+        adapter = OllamaAdapter()
+        
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                side_effect=__import__("httpx").TimeoutException("timeout")
+            )
+            
+            with pytest.raises(ProviderTimeoutError, match="timeout"):
+                await adapter.chat_completion({}, "test-model", 10.0)
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_connection_error(self):
+        """接続エラー時に ProviderError が raise される"""
+        adapter = OllamaAdapter()
+        
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                side_effect=__import__("httpx").ConnectError("connection failed")
+            )
+            
+            with pytest.raises(ProviderError, match="connection failed"):
+                await adapter.chat_completion({}, "test-model", 10.0)
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_error(self):
+        """その他のエラー時に ProviderError が raise される"""
+        adapter = OllamaAdapter()
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.is_success = False
+        mock_response.text = "Internal Server Error"
+        
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            
+            with pytest.raises(ProviderError, match="500"):
+                await adapter.chat_completion({}, "test-model", 10.0)
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_stream_success(self):
+        """ストリーミングが正しく動作する"""
+        adapter = OllamaAdapter()
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.is_success = True
+        
+        async def mock_aiter_bytes():
+            yield b"data: chunk1\n\n"
+            yield b"data: chunk2\n\n"
+        
+        mock_response.aiter_bytes = mock_aiter_bytes
+        
+        mock_client_instance = MagicMock()
+        mock_client_instance.build_request.return_value = MagicMock()
+        mock_client_instance.send = AsyncMock(return_value=mock_response)
+        mock_client_instance.aclose = AsyncMock()
+        
+        with patch("httpx.AsyncClient", return_value=mock_client_instance):
+            chunks = []
+            async for chunk in adapter.chat_completion_stream({}, "test-model", 10.0):
+                chunks.append(chunk)
+            
+            assert len(chunks) == 2
+            assert chunks[0] == b"data: chunk1\n\n"
+            assert chunks[1] == b"data: chunk2\n\n"
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_stream_connection_error(self):
+        """ストリーミング時の接続エラーで ProviderError が raise される"""
+        adapter = OllamaAdapter()
+        
+        mock_client_instance = MagicMock()
+        mock_client_instance.build_request.return_value = MagicMock()
+        mock_client_instance.send = AsyncMock(
+            side_effect=__import__("httpx").ConnectError("connection failed")
+        )
+        mock_client_instance.aclose = AsyncMock()
+        
+        with patch("httpx.AsyncClient", return_value=mock_client_instance):
+            with pytest.raises(ProviderError, match="connection failed"):
+                async for _ in adapter.chat_completion_stream({}, "test-model", 10.0):
+                    pass

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -1,0 +1,178 @@
+import sys
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# base モジュールをモック化（PR1 未マージ時の対応）
+if 'adapters.base' not in sys.modules:
+    from abc import ABC, abstractmethod
+    from typing import AsyncIterator
+    from types import ModuleType
+    base_module = ModuleType('adapters.base')
+    
+    class RateLimitError(Exception):
+        pass
+    
+    class ProviderTimeoutError(Exception):
+        pass
+    
+    class ProviderError(Exception):
+        pass
+    
+    class AbstractLLMAdapter(ABC):
+        @abstractmethod
+        async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
+            pass
+        
+        @abstractmethod
+        async def chat_completion_stream(self, payload: dict, model: str, timeout: float) -> AsyncIterator[bytes]:
+            pass
+    
+    base_module.RateLimitError = RateLimitError
+    base_module.ProviderTimeoutError = ProviderTimeoutError
+    base_module.ProviderError = ProviderError
+    base_module.AbstractLLMAdapter = AbstractLLMAdapter
+    sys.modules['adapters.base'] = base_module
+else:
+    from adapters.base import ProviderError, ProviderTimeoutError, RateLimitError
+
+from adapters.openrouter import OpenRouterAdapter
+
+
+class TestOpenRouterAdapter:
+    """OpenRouterAdapter のテスト"""
+
+    def test_initialization(self):
+        """初期化が正しく行われる"""
+        adapter = OpenRouterAdapter(api_key="test-key", base_url="https://example.com/")
+        assert adapter._api_key == "test-key"
+        assert adapter._base_url == "https://example.com"
+
+    def test_headers(self):
+        """ヘッダーが正しく生成される"""
+        adapter = OpenRouterAdapter(api_key="test-key")
+        headers = adapter._headers()
+        assert headers["Authorization"] == "Bearer test-key"
+        assert headers["Content-Type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_success(self):
+        """正常なレスポンスが返される"""
+        adapter = OpenRouterAdapter(api_key="test-key")
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.is_success = True
+        mock_response.json.return_value = {"result": "success"}
+        
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            
+            result = await adapter.chat_completion(
+                {"messages": [{"role": "user", "content": "test"}]},
+                "test-model",
+                10.0
+            )
+            
+            assert result == {"result": "success"}
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_timeout(self):
+        """タイムアウト時に ProviderTimeoutError が raise される"""
+        adapter = OpenRouterAdapter(api_key="test-key")
+        
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                side_effect=Exception("Timeout")
+            )
+            mock_client.return_value.__aenter__.return_value.post.side_effect = (
+                __import__("httpx").TimeoutException("timeout")
+            )
+            
+            with pytest.raises(ProviderTimeoutError, match="timeout"):
+                await adapter.chat_completion({}, "test-model", 10.0)
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_rate_limit(self):
+        """429 エラー時に RateLimitError が raise される"""
+        adapter = OpenRouterAdapter(api_key="test-key")
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.is_success = False
+        
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            
+            with pytest.raises(RateLimitError, match="429"):
+                await adapter.chat_completion({}, "test-model", 10.0)
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_error(self):
+        """その他のエラー時に ProviderError が raise される"""
+        adapter = OpenRouterAdapter(api_key="test-key")
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.is_success = False
+        mock_response.text = "Internal Server Error"
+        
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                return_value=mock_response
+            )
+            
+            with pytest.raises(ProviderError, match="500"):
+                await adapter.chat_completion({}, "test-model", 10.0)
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_stream_success(self):
+        """ストリーミングが正しく動作する"""
+        adapter = OpenRouterAdapter(api_key="test-key")
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.is_success = True
+        
+        async def mock_aiter_bytes():
+            yield b"data: chunk1\n\n"
+            yield b"data: chunk2\n\n"
+        
+        mock_response.aiter_bytes = mock_aiter_bytes
+        
+        mock_client_instance = MagicMock()
+        mock_client_instance.build_request.return_value = MagicMock()
+        mock_client_instance.send = AsyncMock(return_value=mock_response)
+        mock_client_instance.aclose = AsyncMock()
+        
+        with patch("httpx.AsyncClient", return_value=mock_client_instance):
+            chunks = []
+            async for chunk in adapter.chat_completion_stream({}, "test-model", 10.0):
+                chunks.append(chunk)
+            
+            assert len(chunks) == 2
+            assert chunks[0] == b"data: chunk1\n\n"
+            assert chunks[1] == b"data: chunk2\n\n"
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_stream_rate_limit(self):
+        """ストリーミング時の 429 エラーで RateLimitError が raise される"""
+        adapter = OpenRouterAdapter(api_key="test-key")
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.is_success = False
+        mock_response.aclose = AsyncMock()
+        
+        mock_client_instance = MagicMock()
+        mock_client_instance.build_request.return_value = MagicMock()
+        mock_client_instance.send = AsyncMock(return_value=mock_response)
+        mock_client_instance.aclose = AsyncMock()
+        
+        with patch("httpx.AsyncClient", return_value=mock_client_instance):
+            with pytest.raises(RateLimitError, match="429"):
+                async for _ in adapter.chat_completion_stream({}, "test-model", 10.0):
+                    pass


### PR DESCRIPTION
## 概要

PR1 で定義した `AbstractLLMAdapter` を実装する2つのプロバイダーアダプターを追加します。

## 変更内容

### 追加ファイル

- `adapters/openrouter.py` — OpenRouter API アダプター
- `adapters/ollama.py` — Ollama ローカルアダプター
- `tests/test_openrouter.py` — OpenRouter アダプターのユニットテスト
- `tests/test_ollama.py` — Ollama アダプターのユニットテスト

### 詳細

#### `adapters/openrouter.py`

OpenRouter API を呼び出すアダプター：

- **認証**: Bearer トークン（環境変数 `OPENROUTER_API_KEY`）
- **エンドポイント**: `https://openrouter.ai/api/v1/chat/completions`
- **エラーハンドリング**:
  - 429 → `RateLimitError` を raise（フェイルオーバー対象）
  - タイムアウト → `ProviderTimeoutError` を raise
  - その他 → `ProviderError` を raise
- **ストリーミング対応**: SSE 形式でバイト列を yield

#### `adapters/ollama.py`

Ollama ローカルインスタンス用アダプター（最終防衛線）：

- **エンドポイント**: `http://localhost:11434/v1/chat/completions`（OpenAI 互換）
- **認証**: 不要
- **エラーハンドリング**:
  - 接続失敗 → `ProviderError` を raise
  - タイムアウト → `ProviderTimeoutError` を raise
- **用途**: 全クラウドモデル失敗時のフォールバック

#### テスト

- **`test_openrouter.py`**: 8件のテスト（初期化、ヘッダー、成功/失敗ケース、ストリーミング）
- **`test_ollama.py`**: 9件のテスト（初期化、接続エラー、ストリーミング等）
- **モック使用**: `httpx.AsyncClient` をモック化して HTTP 通信をテスト
- **PR1 未マージ対応**: `adapters.base` を動的にモック化し、依存関係を解決

## テスト結果

```bash
$ pytest tests/test_openrouter.py tests/test_ollama.py -v
============================== 17 passed in 0.10s ==============================
```

## 実装のポイント

- `httpx.AsyncClient` を使用した非同期 HTTP 通信
- ストリーミング時は `aiter_bytes()` でチャンク単位で yield
- エラー種別を適切に分類し、リトライ可否を判断可能に

## レビューポイント

- [ ] エラーハンドリングは適切か
- [ ] タイムアウト処理は正しく動作するか
- [ ] ストリーミング実装に問題はないか
- [ ] テストカバレッジは十分か

## 依存関係

- **前提**: PR1 がマージ済みであること（`AbstractLLMAdapter` が必要）