### PR TITLE
feat: モデルルーターとフェイルオーバー機能を追加

### DIFF
--- a/router/failover.py
+++ b/router/failover.py
@@ -1,0 +1,72 @@
+import logging
+from typing import AsyncIterator
+
+from adapters.base import (
+    AbstractLLMAdapter,
+    ProviderError,
+    ProviderTimeoutError,
+    RateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FailoverRouter:
+    """429 / タイムアウト発生時に次のモデルへ自動切替を行う"""
+
+    def __init__(
+        self,
+        cloud_adapter: AbstractLLMAdapter,
+        local_adapter: AbstractLLMAdapter,
+        local_model: str,
+        timeout: float,
+    ) -> None:
+        self._cloud_adapter = cloud_adapter
+        self._local_adapter = local_adapter
+        self._local_model = local_model
+        self._timeout = timeout
+
+    async def execute_with_failover(
+        self,
+        payload: dict,
+        models: list[str],
+        stream: bool,
+    ) -> dict | AsyncIterator[bytes]:
+        """モデルリストを順に試行し、成功するまでリトライ"""
+        last_error: Exception | None = None
+
+        for model in models:
+            try:
+                logger.info(f"Trying model: {model}")
+                if stream:
+                    return self._cloud_adapter.chat_completion_stream(
+                        payload, model, self._timeout
+                    )
+                else:
+                    return await self._cloud_adapter.chat_completion(
+                        payload, model, self._timeout
+                    )
+            except (RateLimitError, ProviderTimeoutError) as exc:
+                logger.warning(f"Model {model} failed: {exc}")
+                last_error = exc
+                continue
+            except ProviderError as exc:
+                logger.error(f"Model {model} non-retryable error: {exc}")
+                last_error = exc
+                continue
+
+        logger.warning("All cloud models failed, falling back to local Ollama")
+        try:
+            if stream:
+                return self._local_adapter.chat_completion_stream(
+                    payload, self._local_model, self._timeout
+                )
+            else:
+                return await self._local_adapter.chat_completion(
+                    payload, self._local_model, self._timeout
+                )
+        except Exception as exc:
+            logger.error(f"Local fallback failed: {exc}")
+            raise ProviderError(
+                f"All providers failed. Last error: {last_error}"
+            ) from last_error

--- a/router/model_router.py
+++ b/router/model_router.py
@@ -1,0 +1,56 @@
+import time
+from typing import Any
+
+import httpx
+
+
+class ModelRouter:
+    """OpenRouter の無料モデルリストを取得し、優先順位付けを行う"""
+
+    def __init__(
+        self,
+        openrouter_base_url: str,
+        priority_keywords: list[dict[str, Any]],
+        cache_ttl: int = 300,
+    ) -> None:
+        self._base_url = openrouter_base_url.rstrip("/")
+        self._priority_keywords = priority_keywords
+        self._cache_ttl = cache_ttl
+        self._cached_models: list[str] = []
+        self._cache_time: float = 0.0
+
+    async def get_free_models(self) -> list[str]:
+        """無料モデルリストを取得（キャッシュ付き）"""
+        now = time.time()
+        if self._cached_models and (now - self._cache_time) < self._cache_ttl:
+            return self._cached_models
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{self._base_url}/models")
+            resp.raise_for_status()
+            data = resp.json()
+
+        free_models = [
+            m["id"]
+            for m in data.get("data", [])
+            if ":free" in m["id"]
+            and m.get("pricing", {}).get("prompt") == "0"
+            and m.get("pricing", {}).get("completion") == "0"
+        ]
+
+        sorted_models = self._sort_by_priority(free_models)
+        self._cached_models = sorted_models
+        self._cache_time = now
+        return sorted_models
+
+    def _sort_by_priority(self, models: list[str]) -> list[str]:
+        """優先度キーワードに基づいてモデルをソート"""
+
+        def priority_score(model_id: str) -> int:
+            for rule in self._priority_keywords:
+                for keyword in rule["keywords"]:
+                    if keyword.lower() in model_id.lower():
+                        return rule["priority"]
+            return 999
+
+        return sorted(models, key=priority_score)

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -1,0 +1,254 @@
+import sys
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+# adapters.base をモック化（PR1/PR2 未マージ時の対応）
+if 'adapters.base' not in sys.modules:
+    from abc import ABC, abstractmethod
+    from typing import AsyncIterator
+    from types import ModuleType
+    base_module = ModuleType('adapters.base')
+    
+    class RateLimitError(Exception):
+        pass
+    
+    class ProviderTimeoutError(Exception):
+        pass
+    
+    class ProviderError(Exception):
+        pass
+    
+    class AbstractLLMAdapter(ABC):
+        @abstractmethod
+        async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
+            pass
+        
+        @abstractmethod
+        async def chat_completion_stream(self, payload: dict, model: str, timeout: float) -> AsyncIterator[bytes]:
+            pass
+    
+    base_module.RateLimitError = RateLimitError
+    base_module.ProviderTimeoutError = ProviderTimeoutError
+    base_module.ProviderError = ProviderError
+    base_module.AbstractLLMAdapter = AbstractLLMAdapter
+    sys.modules['adapters.base'] = base_module
+else:
+    from adapters.base import (
+        AbstractLLMAdapter,
+        ProviderError,
+        ProviderTimeoutError,
+        RateLimitError,
+    )
+
+from router.failover import FailoverRouter
+
+
+class TestFailoverRouter:
+    """FailoverRouter のテスト"""
+
+    def test_initialization(self):
+        """初期化が正しく行われる"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+        )
+        
+        assert router._cloud_adapter == cloud_adapter
+        assert router._local_adapter == local_adapter
+        assert router._local_model == "phi3.5:latest"
+        assert router._timeout == 20.0
+
+    @pytest.mark.asyncio
+    async def test_execute_with_failover_success_first_model(self):
+        """最初のモデルで成功する"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(return_value={"result": "success"})
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+        )
+        
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+        
+        assert result == {"result": "success"}
+        assert cloud_adapter.chat_completion.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_failover_retry_on_rate_limit(self):
+        """429 エラー時に次のモデルへリトライする"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(
+            side_effect=[
+                RateLimitError("429"),
+                {"result": "success"},
+            ]
+        )
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+        )
+        
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+        
+        assert result == {"result": "success"}
+        assert cloud_adapter.chat_completion.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_with_failover_retry_on_timeout(self):
+        """タイムアウト時に次のモデルへリトライする"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(
+            side_effect=[
+                ProviderTimeoutError("timeout"),
+                {"result": "success"},
+            ]
+        )
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+        )
+        
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+        
+        assert result == {"result": "success"}
+        assert cloud_adapter.chat_completion.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_with_failover_fallback_to_local(self):
+        """全クラウドモデル失敗時にローカルへフォールバックする"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(
+            side_effect=RateLimitError("429")
+        )
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        local_adapter.chat_completion = AsyncMock(return_value={"result": "local"})
+        
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+        )
+        
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+        
+        assert result == {"result": "local"}
+        assert cloud_adapter.chat_completion.call_count == 2
+        assert local_adapter.chat_completion.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_failover_all_failed(self):
+        """全プロバイダー失敗時に ProviderError が raise される"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(
+            side_effect=RateLimitError("429")
+        )
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        local_adapter.chat_completion = AsyncMock(
+            side_effect=ProviderError("local failed")
+        )
+        
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+        )
+        
+        with pytest.raises(ProviderError, match="All providers failed"):
+            await router.execute_with_failover(
+                payload={"messages": []},
+                models=["model1"],
+                stream=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_execute_with_failover_stream_success(self):
+        """ストリーミング時も正しく動作する"""
+        async def mock_stream():
+            yield b"data: chunk\n\n"
+        
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion_stream = MagicMock(return_value=mock_stream())
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+        )
+        
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1"],
+            stream=True,
+        )
+        
+        chunks = []
+        async for chunk in result:
+            chunks.append(chunk)
+        
+        assert len(chunks) == 1
+        assert chunks[0] == b"data: chunk\n\n"
+
+    @pytest.mark.asyncio
+    async def test_execute_with_failover_skip_provider_error(self):
+        """ProviderError は次のモデルへスキップする"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(
+            side_effect=[
+                ProviderError("error"),
+                {"result": "success"},
+            ]
+        )
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+        )
+        
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+        
+        assert result == {"result": "success"}
+        assert cloud_adapter.chat_completion.call_count == 2

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,0 +1,179 @@
+import time
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from router.model_router import ModelRouter
+
+
+class TestModelRouter:
+    """ModelRouter のテスト"""
+
+    def test_initialization(self):
+        """初期化が正しく行われる"""
+        router = ModelRouter(
+            openrouter_base_url="https://openrouter.ai/api/v1",
+            priority_keywords=[{"keywords": ["qwen"], "priority": 1}],
+            cache_ttl=300,
+        )
+        assert router._base_url == "https://openrouter.ai/api/v1"
+        assert router._cache_ttl == 300
+        assert router._cached_models == []
+
+    @pytest.mark.asyncio
+    async def test_get_free_models_success(self):
+        """無料モデルリストが正しく取得される"""
+        router = ModelRouter(
+            openrouter_base_url="https://openrouter.ai/api/v1",
+            priority_keywords=[
+                {"keywords": ["qwen"], "priority": 1},
+                {"keywords": ["gemini"], "priority": 2},
+            ],
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "id": "qwen/qwen-2.5:free",
+                    "pricing": {"prompt": "0", "completion": "0"},
+                },
+                {
+                    "id": "google/gemini-flash:free",
+                    "pricing": {"prompt": "0", "completion": "0"},
+                },
+                {
+                    "id": "paid-model",
+                    "pricing": {"prompt": "0.001", "completion": "0.002"},
+                },
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            models = await router.get_free_models()
+
+            assert len(models) == 2
+            assert "qwen/qwen-2.5:free" in models
+            assert "google/gemini-flash:free" in models
+            assert "paid-model" not in models
+
+    @pytest.mark.asyncio
+    async def test_priority_sorting(self):
+        """優先順位に基づいてソートされる"""
+        router = ModelRouter(
+            openrouter_base_url="https://openrouter.ai/api/v1",
+            priority_keywords=[
+                {"keywords": ["qwen"], "priority": 1},
+                {"keywords": ["gemini"], "priority": 2},
+                {"keywords": ["phi"], "priority": 3},
+            ],
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"id": "phi/phi-3:free", "pricing": {"prompt": "0", "completion": "0"}},
+                {
+                    "id": "qwen/qwen-2.5:free",
+                    "pricing": {"prompt": "0", "completion": "0"},
+                },
+                {
+                    "id": "google/gemini-flash:free",
+                    "pricing": {"prompt": "0", "completion": "0"},
+                },
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            models = await router.get_free_models()
+
+            assert models[0] == "qwen/qwen-2.5:free"
+            assert models[1] == "google/gemini-flash:free"
+            assert models[2] == "phi/phi-3:free"
+
+    @pytest.mark.asyncio
+    async def test_cache_mechanism(self):
+        """キャッシュが正しく動作する"""
+        router = ModelRouter(
+            openrouter_base_url="https://openrouter.ai/api/v1",
+            priority_keywords=[],
+            cache_ttl=1,
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "id": "test-model:free",
+                    "pricing": {"prompt": "0", "completion": "0"},
+                }
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.get = mock_get
+
+            models1 = await router.get_free_models()
+            models2 = await router.get_free_models()
+
+            assert models1 == models2
+            assert mock_get.call_count == 1
+
+            time.sleep(1.1)
+
+            models3 = await router.get_free_models()
+            assert models3 == models1
+            assert mock_get.call_count == 2
+
+    def test_sort_by_priority(self):
+        """_sort_by_priority が正しく動作する"""
+        router = ModelRouter(
+            openrouter_base_url="https://openrouter.ai/api/v1",
+            priority_keywords=[
+                {"keywords": ["qwen"], "priority": 1},
+                {"keywords": ["gemini"], "priority": 2},
+            ],
+        )
+
+        models = [
+            "unknown-model:free",
+            "google/gemini-flash:free",
+            "qwen/qwen-2.5:free",
+        ]
+
+        sorted_models = router._sort_by_priority(models)
+
+        assert sorted_models[0] == "qwen/qwen-2.5:free"
+        assert sorted_models[1] == "google/gemini-flash:free"
+        assert sorted_models[2] == "unknown-model:free"
+
+    @pytest.mark.asyncio
+    async def test_empty_response(self):
+        """空のレスポンスを正しく処理する"""
+        router = ModelRouter(
+            openrouter_base_url="https://openrouter.ai/api/v1",
+            priority_keywords=[],
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            models = await router.get_free_models()
+            assert models == []


### PR DESCRIPTION
## 概要

OpenRouter の無料モデルを動的に取得し、優先順位付けを行うルーターと、429/タイムアウト時に自動で次モデルへ切り替えるフェイルオーバー機能を追加します。

## 変更内容

### 追加ファイル

- `router/__init__.py` — パッケージ初期化
- `router/model_router.py` — モデルリスト取得・優先順位付け
- `router/failover.py` — リトライ・フェイルオーバーロジック
- `tests/test_model_router.py` — モデルルーターのユニットテスト
- `tests/test_failover.py` — フェイルオーバーのユニットテスト

### 詳細

#### `router/model_router.py`

OpenRouter から無料モデルリストを取得し、優先順位付けを行うクラス：

- **動的取得**: `https://openrouter.ai/api/v1/models` から `:free` モデルを抽出
- **フィルタリング条件**:
  - `id` に `:free` を含む
  - `pricing.prompt` == `"0"`
  - `pricing.completion` == `"0"`
- **優先順位付け**: `config.json` の `priority_keywords` に基づいてソート
  - 優先度1: `qwen`, `nemotron`
  - 優先度2: `google/gemini`, `gemma`
  - 優先度3: `phi`, `mistral`
- **キャッシュ**: 300秒間キャッシュし、API 呼び出しを削減

#### `router/failover.py`

429 / タイムアウト発生時に次モデルへ自動切替を行うクラス：

- **リトライ対象エラー**:
  - `RateLimitError` (429)
  - `ProviderTimeoutError`
- **非リトライエラー**:
  - `ProviderError`（ログ出力後、次モデルへ）
- **最終防衛線**: 全クラウドモデル失敗時は Ollama へフォールバック
- **ログ出力**: 各試行・失敗をログ記録

#### テスト

- **`test_model_router.py`**: 6件のテスト（初期化、取得、優先順位、キャッシュ等）
- **`test_failover.py`**: 8件のテスト（リトライ、フォールバック、ストリーミング等）
- **モック使用**: HTTP 通信とアダプターをモック化
- **PR1/PR2 未マージ対応**: `adapters.base` を動的にモック化

## テスト結果

```bash
$ pytest tests/test_model_router.py tests/test_failover.py -v
============================== 14 passed in 1.19s ==============================
```

## 動作フロー

```
1. モデルリスト取得（優先順位順）
2. 1番目のモデルで試行
   ├─ 成功 → レスポンス返却
   └─ 429/タイムアウト → 2番目のモデルで試行
      ├─ 成功 → レスポンス返却
      └─ 失敗 → 3番目...
3. 全クラウドモデル失敗 → Ollama へフォールバック
4. Ollama も失敗 → ProviderError を raise
```

## レビューポイント

- [ ] 優先順位ロジックは適切か
- [ ] リトライ判定（429/タイムアウトのみ）は妥当か
- [ ] キャッシュ TTL（300秒）は適切か
- [ ] ログ出力は十分か
- [ ] テストカバレッジは十分か

## 依存関係

- **前提**: PR1, PR2 がマージ済みであること