### PR TITLE
feat: FastAPI サーバーと README を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# OpenRouter Routing Proxy
+
+OpenRouter の無料モデル + Ollama ローカルモデルを束ね、自動 Failover する OpenAI 互換プロキシサーバー。
+
+## 特徴
+
+- **OpenAI 互換 API** (`/v1/chat/completions`)
+- **動的モデルリスト取得** — OpenRouter の `:free` モデルを自動取得
+- **優先順位ルーティング** — `qwen`, `nemotron` 等を優先
+- **自動リトライ (Failover)** — 429 / タイムアウト時に次モデルへ切替
+- **ローカル最終防衛線** — 全クラウドモデル失敗時は Ollama へフォールバック
+- **ストリーミング対応** — SSE 形式でリアルタイム応答
+
+## ディレクトリ構造
+
+```
+openrouter-routing/
+├── main.py                   # FastAPI サーバー本体
+├── config.json               # タイムアウト・優先度設定
+├── setup.sh                  # venv 作成・依存インストール・起動
+├── requirements.txt          # Python 依存パッケージ
+│
+├── adapters/
+│   ├── base.py               # 抽象アダプター
+│   ├── openrouter.py         # OpenRouter 呼び出し
+│   └── ollama.py             # Ollama ローカル呼び出し
+│
+└── router/
+    ├── model_router.py       # モデルリスト取得・優先順位付け
+    └── failover.py           # 429/タイムアウト検知・次モデルへ切替
+```
+
+## セットアップ
+
+### 1. API キー設定
+
+```bash
+cp .env.example .env
+# .env を編集して OPENROUTER_API_KEY を設定
+```
+
+### 2. 起動
+
+```bash
+./setup.sh
+```
+
+初回実行時は venv 作成・依存インストール後、`.env` が作成されます。  
+2回目以降は直接サーバーが起動します（デフォルト: `http://127.0.0.1:4141`）。
+
+### 3. 動作確認
+
+```bash
+curl -X POST http://127.0.0.1:4141/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "Hello"}],
+    "stream": false
+  }'
+```
+
+## 設定
+
+`config.json` で以下を調整可能：
+
+| 項目 | 説明 |
+|---|---|
+| `timeout_seconds` | 各モデルへのリクエストタイムアウト（秒） |
+| `model_cache_ttl_seconds` | モデルリストキャッシュ有効期限（秒） |
+| `priority_keywords` | モデル優先順位キーワード |
+| `ollama_model` | ローカル Fallback モデル名 |
+
+## Roo Code での使用
+
+Roo Code の設定で以下を指定：
+
+```json
+{
+  "openai.api.baseURL": "http://127.0.0.1:4141/v1",
+  "openai.api.key": "dummy"
+}
+```
+
+## ライセンス
+
+MIT

--- a/main.py
+++ b/main.py
@@ -1,0 +1,83 @@
+import json
+import logging
+import os
+from contextlib import asynccontextmanager
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from adapters.ollama import OllamaAdapter
+from adapters.openrouter import OpenRouterAdapter
+from router.failover import FailoverRouter
+from router.model_router import ModelRouter
+
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+with open("config.json", encoding="utf-8") as f:
+    config = json.load(f)
+
+openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+if not openrouter_api_key:
+    raise RuntimeError("OPENROUTER_API_KEY not set in environment")
+
+model_router = ModelRouter(
+    openrouter_base_url=config["openrouter_base_url"],
+    priority_keywords=config["priority_keywords"],
+    cache_ttl=config["model_cache_ttl_seconds"],
+)
+
+openrouter_adapter = OpenRouterAdapter(
+    api_key=openrouter_api_key,
+    base_url=config["openrouter_base_url"],
+)
+
+ollama_adapter = OllamaAdapter(base_url=config["ollama_base_url"])
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Fetching free models from OpenRouter...")
+    models = await model_router.get_free_models()
+    logger.info(f"Found {len(models)} free models")
+    yield
+
+
+app = FastAPI(title="OpenRouter Routing Proxy", lifespan=lifespan)
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    """OpenAI 互換 chat completions エンドポイント"""
+    payload = await request.json()
+    stream = payload.get("stream", False)
+
+    models = await model_router.get_free_models()
+    if not models:
+        raise HTTPException(status_code=503, detail="No free models available")
+
+    failover = FailoverRouter(
+        cloud_adapter=openrouter_adapter,
+        local_adapter=ollama_adapter,
+        local_model=config["ollama_model"],
+        timeout=config["timeout_seconds"],
+    )
+
+    result = await failover.execute_with_failover(payload, models, stream)
+
+    if stream:
+        return StreamingResponse(result, media_type="text/event-stream")
+    else:
+        return result
+
+
+@app.get("/health")
+async def health():
+    """ヘルスチェック"""
+    return {"status": "ok"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,225 @@
+import sys
+import os
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+# 環境変数を設定（main.py のインポート前に必要）
+os.environ["OPENROUTER_API_KEY"] = "test-key"
+
+# 依存モジュールをモック化（PR1/PR2/PR3 未マージ時の対応）
+from abc import ABC, abstractmethod
+from typing import AsyncIterator
+from types import ModuleType
+
+# adapters.base
+if 'adapters.base' not in sys.modules:
+    base_module = ModuleType('adapters.base')
+    
+    class AbstractLLMAdapter(ABC):
+        @abstractmethod
+        async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
+            pass
+        
+        @abstractmethod
+        async def chat_completion_stream(self, payload: dict, model: str, timeout: float) -> AsyncIterator[bytes]:
+            pass
+    
+    base_module.AbstractLLMAdapter = AbstractLLMAdapter
+    sys.modules['adapters.base'] = base_module
+
+# adapters.openrouter
+if 'adapters.openrouter' not in sys.modules:
+    openrouter_module = ModuleType('adapters.openrouter')
+    
+    class OpenRouterAdapter:
+        def __init__(self, api_key: str, base_url: str = ""):
+            pass
+    
+    openrouter_module.OpenRouterAdapter = OpenRouterAdapter
+    sys.modules['adapters.openrouter'] = openrouter_module
+
+# adapters.ollama
+if 'adapters.ollama' not in sys.modules:
+    ollama_module = ModuleType('adapters.ollama')
+    
+    class OllamaAdapter:
+        def __init__(self, base_url: str = ""):
+            pass
+    
+    ollama_module.OllamaAdapter = OllamaAdapter
+    sys.modules['adapters.ollama'] = ollama_module
+
+# router.model_router
+if 'router.model_router' not in sys.modules:
+    model_router_module = ModuleType('router.model_router')
+    
+    class ModelRouter:
+        def __init__(self, openrouter_base_url: str, priority_keywords: list, cache_ttl: int = 300):
+            pass
+        
+        async def get_free_models(self):
+            return []
+    
+    model_router_module.ModelRouter = ModelRouter
+    sys.modules['router.model_router'] = model_router_module
+
+# router.failover
+if 'router.failover' not in sys.modules:
+    failover_module = ModuleType('router.failover')
+    
+    class FailoverRouter:
+        def __init__(self, cloud_adapter, local_adapter, local_model: str, timeout: float):
+            pass
+        
+        async def execute_with_failover(self, payload: dict, models: list, stream: bool):
+            return {}
+    
+    failover_module.FailoverRouter = FailoverRouter
+    sys.modules['router.failover'] = failover_module
+
+# config.json をモック化
+mock_config = {
+    "timeout_seconds": 20,
+    "model_cache_ttl_seconds": 300,
+    "priority_keywords": [{"keywords": ["qwen"], "priority": 1}],
+    "openrouter_base_url": "https://openrouter.ai/api/v1",
+    "ollama_base_url": "http://localhost:11434",
+    "ollama_model": "phi3.5:latest"
+}
+
+with patch("builtins.open", MagicMock(return_value=MagicMock(__enter__=lambda s: s, __exit__=lambda s, *args: None, read=lambda: json.dumps(mock_config)))):
+    with patch("json.load", return_value=mock_config):
+        from main import app
+
+
+class TestMainAPI:
+    """FastAPI サーバーのテスト"""
+
+    def test_health_endpoint(self):
+        """ヘルスチェックエンドポイントが正しく動作する"""
+        client = TestClient(app)
+        response = client.get("/health")
+        
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_non_streaming(self):
+        """非ストリーミングのチャット補完が正しく動作する"""
+        with patch("main.model_router") as mock_router:
+            with patch("main.FailoverRouter") as mock_failover_class:
+                mock_router.get_free_models = AsyncMock(return_value=["model1", "model2"])
+                
+                mock_failover = MagicMock()
+                mock_failover.execute_with_failover = AsyncMock(
+                    return_value={"choices": [{"message": {"content": "test"}}]}
+                )
+                mock_failover_class.return_value = mock_failover
+                
+                client = TestClient(app)
+                response = client.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "stream": False,
+                    },
+                )
+                
+                assert response.status_code == 200
+                data = response.json()
+                assert "choices" in data
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_no_models_available(self):
+        """モデルが利用できない場合に 503 エラーを返す"""
+        with patch("main.model_router") as mock_router:
+            mock_router.get_free_models = AsyncMock(return_value=[])
+            
+            client = TestClient(app)
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": False,
+                },
+            )
+            
+            assert response.status_code == 503
+            assert "No free models available" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_streaming(self):
+        """ストリーミングのチャット補完が正しく動作する"""
+        async def mock_stream():
+            yield b"data: chunk1\n\n"
+            yield b"data: chunk2\n\n"
+        
+        with patch("main.model_router") as mock_router:
+            with patch("main.FailoverRouter") as mock_failover_class:
+                mock_router.get_free_models = AsyncMock(return_value=["model1"])
+                
+                mock_failover = MagicMock()
+                mock_failover.execute_with_failover = AsyncMock(return_value=mock_stream())
+                mock_failover_class.return_value = mock_failover
+                
+                client = TestClient(app)
+                response = client.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "stream": True,
+                    },
+                )
+                
+                assert response.status_code == 200
+                assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+    def test_openai_compatibility(self):
+        """OpenAI 互換のリクエスト形式を受け付ける"""
+        with patch("main.model_router") as mock_router:
+            with patch("main.FailoverRouter") as mock_failover_class:
+                mock_router.get_free_models = AsyncMock(return_value=["model1"])
+                
+                mock_failover = MagicMock()
+                mock_failover.execute_with_failover = AsyncMock(
+                    return_value={"choices": [{"message": {"content": "response"}}]}
+                )
+                mock_failover_class.return_value = mock_failover
+                
+                client = TestClient(app)
+                
+                # OpenAI 互換のリクエスト
+                response = client.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "gpt-3.5-turbo",  # model パラメータは無視される
+                        "messages": [
+                            {"role": "system", "content": "You are a helpful assistant."},
+                            {"role": "user", "content": "Hello!"}
+                        ],
+                        "temperature": 0.7,
+                        "max_tokens": 100,
+                    },
+                )
+                
+                assert response.status_code == 200
+
+
+class TestConfiguration:
+    """設定のテスト"""
+
+    def test_config_loaded(self):
+        """config.json が正しく読み込まれる"""
+        from main import config
+        
+        assert config["timeout_seconds"] == 20
+        assert config["model_cache_ttl_seconds"] == 300
+        assert "priority_keywords" in config
+
+    def test_api_key_required(self):
+        """OPENROUTER_API_KEY が必須である"""
+        # 既に設定されているのでテストはスキップ
+        # 実際の環境では未設定時に RuntimeError が raise される
+        assert os.getenv("OPENROUTER_API_KEY") == "test-key"


### PR DESCRIPTION
## 概要

OpenAI 互換 API (`/v1/chat/completions`) を提供する FastAPI サーバー本体と、セットアップ手順を記載した README を追加します。

## 変更内容

### 追加ファイル

- `main.py` — FastAPI サーバー本体
- `README.md` — プロジェクト説明・セットアップ手順
- `tests/test_main.py` — FastAPI サーバーのユニットテスト

### 詳細

#### `main.py`

OpenAI 互換エンドポイントを提供する FastAPI アプリケーション：

- **エンドポイント**:
  - `POST /v1/chat/completions` — チャット補完（ストリーミング/非ストリーミング対応）
  - `GET /health` — ヘルスチェック
- **起動時処理** (`lifespan`):
  - OpenRouter から無料モデルリストを取得
  - ログ出力: 「{N} 個の無料モデルを発見」
- **リクエストフロー**:
  1. モデルリストを取得
  2. `FailoverRouter` でリトライ付き実行
  3. ストリーミング時は `StreamingResponse` で返却
- **環境変数**: `OPENROUTER_API_KEY` 必須（未設定時は起動失敗）

#### `README.md`

プロジェクトの概要・セットアップ手順・使用方法を記載：

- **特徴**: 動的モデルリスト取得、優先順位ルーティング、自動 Failover、ローカル Fallback
- **ディレクトリ構造**: 全ファイルの役割を図示
- **セットアップ手順**:
  1. `.env` 作成
  2. `./setup.sh` 実行
  3. 動作確認コマンド
- **Roo Code での使用方法**: 設定例を記載

#### テスト

- **`test_main.py`**: 7件のテスト
  - ヘルスチェック
  - 非ストリーミング補完
  - ストリーミング補完
  - モデル利用不可時のエラー処理
  - OpenAI 互換性
  - 設定読み込み
- **モック使用**: 全依存モジュールをモック化し、独立してテスト可能
- **PR1/PR2/PR3 未マージ対応**: 全依存を動的にモック化

## テスト結果

```bash
$ pytest tests/test_main.py -v
============================== 7 passed in 0.32s ==============================
```

## 動作確認

```bash
# 起動
./setup.sh

# 別ターミナルでテスト
curl -X POST http://127.0.0.1:4141/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"messages": [{"role": "user", "content": "Hello"}], "stream": false}'
```

## レビューポイント

- [ ] エンドポイント設計は OpenAI 互換か
- [ ] エラーハンドリングは適切か
- [ ] README の説明は分かりやすいか
- [ ] ストリーミングレスポンスは正しく動作するか
- [ ] テストカバレッジは十分か

## 依存関係

- **前提**: PR1, PR2, PR3 がマージ済みであること