### PR TITLE
test: テスト間のモジュール汚染を修正

### DIFF
--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -2,44 +2,17 @@ import sys
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-# adapters.base をモック化（PR1/PR2 未マージ時の対応）
-if 'adapters.base' not in sys.modules:
-    from abc import ABC, abstractmethod
-    from typing import AsyncIterator
-    from types import ModuleType
-    base_module = ModuleType('adapters.base')
-    
-    class RateLimitError(Exception):
-        pass
-    
-    class ProviderTimeoutError(Exception):
-        pass
-    
-    class ProviderError(Exception):
-        pass
-    
-    class AbstractLLMAdapter(ABC):
-        @abstractmethod
-        async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
-            pass
-        
-        @abstractmethod
-        async def chat_completion_stream(self, payload: dict, model: str, timeout: float) -> AsyncIterator[bytes]:
-            pass
-    
-    base_module.RateLimitError = RateLimitError
-    base_module.ProviderTimeoutError = ProviderTimeoutError
-    base_module.ProviderError = ProviderError
-    base_module.AbstractLLMAdapter = AbstractLLMAdapter
-    sys.modules['adapters.base'] = base_module
-else:
-    from adapters.base import (
-        AbstractLLMAdapter,
-        ProviderError,
-        ProviderTimeoutError,
-        RateLimitError,
-    )
+# モジュールを強制的に再読み込み（他のテストでのモックの影響を排除）
+for mod in list(sys.modules.keys()):
+    if mod.startswith('adapters.') or mod.startswith('router.'):
+        del sys.modules[mod]
 
+from adapters.base import (
+    AbstractLLMAdapter,
+    ProviderError,
+    ProviderTimeoutError,
+    RateLimitError,
+)
 from router.failover import FailoverRouter
 
 

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -1,6 +1,12 @@
+import sys
 import time
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+# モジュールを強制的に再読み込み（他のテストでのモックの影響を排除）
+for mod in list(sys.modules.keys()):
+    if mod.startswith('adapters.') or mod.startswith('router.'):
+        del sys.modules[mod]
 
 from router.model_router import ModelRouter
 

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -2,35 +2,12 @@ import sys
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-# base モジュールをモック化（PR1 未マージ時の対応）
-if 'adapters.base' not in sys.modules:
-    from abc import ABC, abstractmethod
-    from typing import AsyncIterator
-    from types import ModuleType
-    base_module = ModuleType('adapters.base')
-    
-    class ProviderTimeoutError(Exception):
-        pass
-    
-    class ProviderError(Exception):
-        pass
-    
-    class AbstractLLMAdapter(ABC):
-        @abstractmethod
-        async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
-            pass
-        
-        @abstractmethod
-        async def chat_completion_stream(self, payload: dict, model: str, timeout: float) -> AsyncIterator[bytes]:
-            pass
-    
-    base_module.ProviderTimeoutError = ProviderTimeoutError
-    base_module.ProviderError = ProviderError
-    base_module.AbstractLLMAdapter = AbstractLLMAdapter
-    sys.modules['adapters.base'] = base_module
-else:
-    from adapters.base import ProviderError, ProviderTimeoutError
+# モジュールを強制的に再読み込み（他のテストでのモックの影響を排除）
+for mod in list(sys.modules.keys()):
+    if mod.startswith('adapters.') or mod.startswith('router.'):
+        del sys.modules[mod]
 
+from adapters.base import ProviderError, ProviderTimeoutError
 from adapters.ollama import OllamaAdapter
 
 

--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -1,40 +1,14 @@
 import sys
+import importlib
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-# base モジュールをモック化（PR1 未マージ時の対応）
-if 'adapters.base' not in sys.modules:
-    from abc import ABC, abstractmethod
-    from typing import AsyncIterator
-    from types import ModuleType
-    base_module = ModuleType('adapters.base')
-    
-    class RateLimitError(Exception):
-        pass
-    
-    class ProviderTimeoutError(Exception):
-        pass
-    
-    class ProviderError(Exception):
-        pass
-    
-    class AbstractLLMAdapter(ABC):
-        @abstractmethod
-        async def chat_completion(self, payload: dict, model: str, timeout: float) -> dict:
-            pass
-        
-        @abstractmethod
-        async def chat_completion_stream(self, payload: dict, model: str, timeout: float) -> AsyncIterator[bytes]:
-            pass
-    
-    base_module.RateLimitError = RateLimitError
-    base_module.ProviderTimeoutError = ProviderTimeoutError
-    base_module.ProviderError = ProviderError
-    base_module.AbstractLLMAdapter = AbstractLLMAdapter
-    sys.modules['adapters.base'] = base_module
-else:
-    from adapters.base import ProviderError, ProviderTimeoutError, RateLimitError
+# モジュールを強制的に再読み込み（他のテストでのモックの影響を排除）
+for mod in list(sys.modules.keys()):
+    if mod.startswith('adapters.') or mod.startswith('router.'):
+        del sys.modules[mod]
 
+from adapters.base import ProviderError, ProviderTimeoutError, RateLimitError
 from adapters.openrouter import OpenRouterAdapter
 
 


### PR DESCRIPTION
## 概要

テスト間でモジュールのモック状態が汚染され、全テスト実行時に失敗する問題を修正しました。

## 変更内容

- :  のクリア処理を追加
- :  のクリア処理を追加  
- :  のクリア処理を追加
- :  のクリア処理を追加

## テスト結果



## 技術的な詳細

テスト間で  に残るモック化されたモジュールが、後続のテストに影響を与える問題を解決。各テストファイルの先頭で関連モジュールを強制的にクリアし、実際の実装を正しく読み込むようにしました。