### PR TITLE
日本語に弱いモデルの除外と新ベンダー検出機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 build/
 .DS_Store
 *.log
+known_vendors.json

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ curl -X POST http://127.0.0.1:4141/v1/chat/completions \
 |---|---|
 | `timeout_seconds` | 各モデルへのリクエストタイムアウト（秒） |
 | `model_cache_ttl_seconds` | モデルリストキャッシュ有効期限（秒） |
+| `exclude_keywords` | 除外するモデルのキーワード（日本語に弱いモデル等） |
 | `priority_keywords` | モデル優先順位キーワード |
 | `ollama_model` | ローカル Fallback モデル名 |
 

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
   "openrouter_base_url": "https://openrouter.ai/api/v1",
   "ollama_base_url": "http://localhost:11434",
   "ollama_model": "phi3.5:latest",
+  "exclude_keywords": ["dolphin", "liquid", "arcee"],
   "priority_keywords": [
     {"keywords": ["120b", "405b"], "priority": 99},
     {"keywords": ["20b", "24b", "27b", "30b", "31b"], "priority": 1},

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ if not openrouter_api_key:
 model_router = ModelRouter(
     openrouter_base_url=config["openrouter_base_url"],
     priority_keywords=config["priority_keywords"],
+    exclude_keywords=config.get("exclude_keywords"),
     cache_ttl=config["model_cache_ttl_seconds"],
 )
 

--- a/router/model_router.py
+++ b/router/model_router.py
@@ -11,10 +11,12 @@ class ModelRouter:
         self,
         openrouter_base_url: str,
         priority_keywords: list[dict[str, Any]],
+        exclude_keywords: list[str] | None = None,
         cache_ttl: int = 300,
     ) -> None:
         self._base_url = openrouter_base_url.rstrip("/")
         self._priority_keywords = priority_keywords
+        self._exclude_keywords = exclude_keywords or []
         self._cache_ttl = cache_ttl
         self._cached_models: list[str] = []
         self._cache_time: float = 0.0
@@ -38,7 +40,8 @@ class ModelRouter:
             and m.get("pricing", {}).get("completion") == "0"
         ]
 
-        sorted_models = self._sort_by_priority(free_models)
+        filtered_models = self._filter_excluded(free_models)
+        sorted_models = self._sort_by_priority(filtered_models)
         self._cached_models = sorted_models
         self._cache_time = now
         return sorted_models
@@ -54,3 +57,19 @@ class ModelRouter:
             return 999
 
         return sorted(models, key=priority_score)
+
+    def _filter_excluded(self, models: list[str]) -> list[str]:
+        """除外キーワードに該当するモデルをフィルタリング"""
+        if not self._exclude_keywords:
+            return models
+
+        filtered = []
+        for model_id in models:
+            is_excluded = any(
+                keyword.lower() in model_id.lower()
+                for keyword in self._exclude_keywords
+            )
+            if not is_excluded:
+                filtered.append(model_id)
+
+        return filtered

--- a/router/model_router.py
+++ b/router/model_router.py
@@ -1,7 +1,12 @@
+import json
+import logging
+import os
 import time
 from typing import Any
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class ModelRouter:
@@ -20,6 +25,7 @@ class ModelRouter:
         self._cache_ttl = cache_ttl
         self._cached_models: list[str] = []
         self._cache_time: float = 0.0
+        self._known_vendors_file = "known_vendors.json"
 
     async def get_free_models(self) -> list[str]:
         """無料モデルリストを取得（キャッシュ付き）"""
@@ -32,14 +38,17 @@ class ModelRouter:
             resp.raise_for_status()
             data = resp.json()
 
+        all_models = data.get("data", [])
+
         free_models = [
             m["id"]
-            for m in data.get("data", [])
+            for m in all_models
             if ":free" in m["id"]
             and m.get("pricing", {}).get("prompt") == "0"
             and m.get("pricing", {}).get("completion") == "0"
         ]
 
+        self._detect_new_vendors(all_models, free_models)
         filtered_models = self._filter_excluded(free_models)
         sorted_models = self._sort_by_priority(filtered_models)
         self._cached_models = sorted_models
@@ -73,3 +82,62 @@ class ModelRouter:
                 filtered.append(model_id)
 
         return filtered
+
+    def _detect_new_vendors(self, all_models: list[dict], free_models: list[str]) -> None:
+        """新しいベンダーを検出し、Freeモデルがある場合は警告"""
+        current_vendors = set(
+            m["id"].split("/")[0] for m in all_models if "/" in m["id"]
+        )
+
+        known_vendors = self._load_known_vendors()
+
+        if not known_vendors:
+            self._save_known_vendors(current_vendors)
+            return
+
+        new_vendors = current_vendors - known_vendors
+
+        if new_vendors:
+            free_vendor_models = {}
+            for model_id in free_models:
+                if "/" in model_id:
+                    vendor = model_id.split("/")[0]
+                    if vendor in new_vendors:
+                        if vendor not in free_vendor_models:
+                            free_vendor_models[vendor] = []
+                        free_vendor_models[vendor].append(model_id)
+
+            if free_vendor_models:
+                logger.warning(
+                    "\n" + "="*70 + "\n"
+                    "新しいベンダーのFreeモデルが検出されました。\n"
+                    "ブラックリスト(exclude_keywords)への追加を検討してください:\n"
+                )
+                for vendor in sorted(free_vendor_models.keys()):
+                    logger.warning(f"  [{vendor}]")
+                    for model in free_vendor_models[vendor]:
+                        logger.warning(f"    - {model}")
+                logger.warning("="*70)
+
+        self._save_known_vendors(current_vendors)
+
+    def _load_known_vendors(self) -> set[str]:
+        """既知のベンダーリストをファイルから読み込み"""
+        if not os.path.exists(self._known_vendors_file):
+            return set()
+
+        try:
+            with open(self._known_vendors_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                return set(data.get("vendors", []))
+        except Exception as e:
+            logger.error(f"Failed to load known vendors: {e}")
+            return set()
+
+    def _save_known_vendors(self, vendors: set[str]) -> None:
+        """ベンダーリストをファイルに保存"""
+        try:
+            with open(self._known_vendors_file, "w", encoding="utf-8") as f:
+                json.dump({"vendors": sorted(vendors)}, f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            logger.error(f"Failed to save known vendors: {e}")


### PR DESCRIPTION
## 概要

日本語に弱いモデルを除外し、新しいベンダーのFreeモデルを検出する機能を追加

## 変更内容

### 1. 除外キーワードフィルタ
- `config.json` に `exclude_keywords` を追加
- 日本語に弱いモデル（`dolphin`, `liquid`, `arcee`）を除外
- 既存のサイズベース優先度ロジックは維持

### 2. 新ベンダー検出
- 全モデルからベンダーリストを抽出し `known_vendors.json` に保存
- 新しいベンダーのFreeモデルが出現した場合に警告表示
- ブラックリスト追加を検討すべきモデルを通知

## 動作確認

- [x] サーバー起動・動作確認済み
- [x] 除外フィルタが正常動作（24モデル → 20モデル）
- [x] 優先順位が正常動作（日本語対応モデル優先）

## 影響範囲

- モデル選択ロジックのみ
- API互換性は維持
- 既存機能への影響なし