### PR TITLE
docs: README.mdにcommit-msg hook設定と開発ルール節を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ OpenRouter の無料モデル + Ollama ローカルモデルを束ね、自動 F
 ```bash
 # Git hooksの参照先をリポジトリ内の.githooksに変更し、実行権限を付与
 git config core.hooksPath .githooks
-chmod +x .githooks/pre-commit .githooks/pre-push
+chmod +x .githooks/pre-commit .githooks/pre-push .githooks/commit-msg
 ```
+
+これにより、コミット時の文字コード、改行コード、命名規則、シークレット混入等のチェックが自動実行されます。
 
 ## 特徴
 
@@ -91,6 +93,14 @@ Roo Code の設定で以下を指定：
   "openai.api.key": "dummy"
 }
 ```
+
+## 開発ルール
+
+詳細は `AGENTS.md` を参照してください。
+
+- Git Hookで物理的に強制される制約に従う
+- 環境/Git制約違反時は `.githooks/` のエラーログに従い修正する
+- 機密情報（APIキー等）は `.env` で管理しハードコードしない
 
 ## ライセンス
 


### PR DESCRIPTION
## 概要
`README.md` を template / book-checker の構造に合わせ、**本プロジェクトに実害のある不整合のみ**最小差分で修正する。

## 変更点

### 1. `commit-msg` hook の chmod 漏れを修正
- `.githooks/commit-msg` は実在するが、README のセットアップ手順に chmod 対象として含まれておらず、初回セットアップ時に実行権限が付与されない
- template / book-checker の手順に揃えて3ファイルすべてを指定

### 2. `## 開発ルール` セクションを追加
- これまで README 上に `AGENTS.md` への導線が存在しなかった
- template / book-checker 共通パターンに揃えて末尾に追加
- 本プロジェクト固有の事項として `.env` によるAPIキー管理に言及

## スコープ外（変更しない）
- 特徴・ディレクトリ構造・Roo Code 連携など、プロジェクト固有の既存記述はそのまま
- 技術スタック表（book-checker 固有）は強制しない