### PR TITLE
feat: ツール呼び出し対応の自動検証機能と優先度ルール整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 .DS_Store
 *.log
 known_vendors.json
+tool_support_cache.json

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ chmod +x .githooks/pre-commit .githooks/pre-push .githooks/commit-msg
 - **自動リトライ (Failover)** — 429 / タイムアウト時に次モデルへ切替
 - **ローカル最終防衛線** — 全クラウドモデル失敗時は Ollama へフォールバック
 - **ストリーミング対応** — SSE 形式でリアルタイム応答
+- **ツール呼び出し自動検証** — 新規モデル検出時に function calling の可否を自動テストし、非対応モデルを自動除外
 
 ## ディレクトリ構造
 
@@ -38,8 +39,10 @@ openrouter-routing/
 │   └── ollama.py             # Ollama ローカル呼び出し
 │
 └── router/
-    ├── model_router.py       # モデルリスト取得・優先順位付け
-    └── failover.py           # 429/タイムアウト検知・次モデルへ切替
+    ├── model_router.py            # モデルリスト取得・優先順位付け
+    ├── failover.py                # 429/タイムアウト検知・次モデルへ切替
+    ├── tool_verifier.py           # モデルのツール呼び出し対応を検証
+    └── tool_support_registry.py   # ツール対応モデルのキャッシュ管理
 ```
 
 ## セットアップ
@@ -82,6 +85,17 @@ curl -X POST http://127.0.0.1:4141/v1/chat/completions \
 | `exclude_keywords` | 除外するモデルのキーワード（日本語に弱いモデル等） |
 | `priority_keywords` | モデル優先順位キーワード |
 | `ollama_model` | ローカル Fallback モデル名 |
+| `verify_tool_support` | 起動時に新規モデルのツール呼び出し対応を検証する（デフォルト `true`） |
+| `verify_timeout_seconds` | 検証リクエストのタイムアウト（秒） |
+| `tool_support_cache_file` | 検証結果のキャッシュファイル名 |
+
+### ツール呼び出し検証の動作
+
+- 起動時、OpenRouter のモデルリスト中 **キャッシュに未記録のモデル** のみ検証します
+- 簡単な function calling リクエストを送り、`tool_calls` が返るかを確認します
+- 非対応と判定されたモデルは以降のリクエストから自動除外されます
+- 検証に失敗（429 / タイムアウト等）した場合は判定保留とし、次回起動時に再試行します
+- キャッシュファイル（`tool_support_cache.json`）は Git 管理外です
 
 ## Roo Code での使用
 

--- a/config.json
+++ b/config.json
@@ -4,6 +4,9 @@
   "openrouter_base_url": "https://openrouter.ai/api/v1",
   "ollama_base_url": "http://localhost:11434",
   "ollama_model": "phi3.5:latest",
+  "verify_tool_support": true,
+  "verify_timeout_seconds": 15,
+  "tool_support_cache_file": "tool_support_cache.json",
   "exclude_keywords": ["dolphin", "liquid", "arcee"],
   "priority_keywords": [
     {"keywords": ["120b", "405b"], "priority": 99},

--- a/config.json
+++ b/config.json
@@ -9,9 +9,10 @@
   "tool_support_cache_file": "tool_support_cache.json",
   "exclude_keywords": ["dolphin", "liquid", "arcee"],
   "priority_keywords": [
-    {"keywords": ["120b", "405b"], "priority": 99},
-    {"keywords": ["20b", "24b", "27b", "30b", "31b"], "priority": 1},
-    {"keywords": ["70b", "80b"], "priority": 2},
-    {"keywords": ["3b", "4b", "7b", "9b", "12b"], "priority": 3}
+    {"keywords": ["nano", "mini", "lite"], "priority": 98},
+    {"keywords": ["50b", "60b", "70b", "80b", "90b"], "priority": 1},
+    {"keywords": ["30b", "32b", "33b", "34b", "40b", "49b"], "priority": 2},
+    {"keywords": ["100b", "120b", "140b", "200b", "235b", "400b", "405b"], "priority": 3},
+    {"keywords": ["10b", "11b", "12b", "13b", "14b", "17b", "20b"], "priority": 4}
   ]
 }

--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from adapters.ollama import OllamaAdapter
 from adapters.openrouter import OpenRouterAdapter
 from router.failover import FailoverRouter
 from router.model_router import ModelRouter
+from router.tool_support_registry import ToolSupportRegistry
+from router.tool_verifier import verify_tool_support
 
 load_dotenv()
 
@@ -41,12 +43,53 @@ openrouter_adapter = OpenRouterAdapter(
 
 ollama_adapter = OllamaAdapter(base_url=config["ollama_base_url"])
 
+tool_support_registry = ToolSupportRegistry(
+    cache_file=config.get("tool_support_cache_file", "tool_support_cache.json")
+)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Fetching free models from OpenRouter...")
     models = await model_router.get_free_models()
     logger.info(f"Found {len(models)} free models")
+
+    pruned = tool_support_registry.prune(models)
+    if pruned:
+        logger.info(f"Pruned {pruned} stale models from tool support cache")
+
+    if config.get("verify_tool_support", True):
+        unverified = tool_support_registry.get_unverified(models)
+        if unverified:
+            logger.info(
+                f"{len(unverified)} new models detected, verifying tool support..."
+            )
+            verify_timeout = float(config.get("verify_timeout_seconds", 15))
+            for m in unverified:
+                result = await verify_tool_support(
+                    openrouter_adapter, m, verify_timeout
+                )
+                if result is None:
+                    logger.info(
+                        f"  ? {m} (verification deferred, will retry next startup)"
+                    )
+                elif result:
+                    tool_support_registry.mark(m, True)
+                    logger.info(f"  OK  {m}")
+                else:
+                    tool_support_registry.mark(m, False)
+                    logger.warning(
+                        f"  NG  {m} - tool calling NOT supported (auto-excluded)"
+                    )
+            tool_support_registry.save()
+
+    unsupported = tool_support_registry.unsupported_models()
+    if unsupported:
+        logger.warning(
+            "以下のモデルはツール呼び出しに非対応のため自動除外されます "
+            f"({len(unsupported)} 件): {unsupported}"
+        )
+
     yield
 
 
@@ -63,6 +106,7 @@ async def chat_completions(request: Request):
     payload.pop("model", None)
 
     models = await model_router.get_free_models()
+    models = tool_support_registry.filter_supported(models)
     if not models:
         raise HTTPException(status_code=503, detail="No free models available")
 

--- a/router/tool_support_registry.py
+++ b/router/tool_support_registry.py
@@ -1,0 +1,77 @@
+"""モデルごとのツール呼び出し対応状況を永続化するレジストリ。
+
+- 一度検証したモデルはキャッシュファイルに記録し、次回以降は再検証しない。
+- 未検証モデルは「対応している」と楽観的に扱う（API エラーによる誤除外を避けるため）。
+- 明示的に「非対応」と記録されたモデルのみフィルタで除外する。
+"""
+import json
+import logging
+import os
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class ToolSupportRegistry:
+    """モデルごとの tool calling サポート状況を管理する。"""
+
+    def __init__(self, cache_file: str = "tool_support_cache.json") -> None:
+        self._cache_file = cache_file
+        self._cache: dict[str, dict[str, Any]] = self._load()
+
+    def _load(self) -> dict[str, dict[str, Any]]:
+        if not os.path.exists(self._cache_file):
+            return {}
+        try:
+            with open(self._cache_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return data
+            logger.warning(
+                f"Tool support cache has unexpected format, resetting: {self._cache_file}"
+            )
+            return {}
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"Failed to load tool support cache: {exc}")
+            return {}
+
+    def save(self) -> None:
+        try:
+            with open(self._cache_file, "w", encoding="utf-8") as f:
+                json.dump(self._cache, f, indent=2, ensure_ascii=False, sort_keys=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"Failed to save tool support cache: {exc}")
+
+    def get_unverified(self, models: list[str]) -> list[str]:
+        """キャッシュに未記録のモデルのみを返す。"""
+        return [m for m in models if m not in self._cache]
+
+    def mark(self, model: str, supported: bool) -> None:
+        self._cache[model] = {
+            "tool_support": bool(supported),
+            "verified_at": time.time(),
+        }
+
+    def is_supported(self, model: str) -> bool:
+        """未検証は True（楽観的）。明示的に False と記録されている場合のみ False。"""
+        entry = self._cache.get(model)
+        if entry is None:
+            return True
+        return bool(entry.get("tool_support", True))
+
+    def filter_supported(self, models: list[str]) -> list[str]:
+        return [m for m in models if self.is_supported(m)]
+
+    def unsupported_models(self) -> list[str]:
+        return sorted(
+            m for m, v in self._cache.items() if not v.get("tool_support", True)
+        )
+
+    def prune(self, current_models: list[str]) -> int:
+        """モデルリストから消えたものをキャッシュから削除する。削除件数を返す。"""
+        current_set = set(current_models)
+        to_remove = [m for m in self._cache if m not in current_set]
+        for m in to_remove:
+            del self._cache[m]
+        return len(to_remove)

--- a/router/tool_verifier.py
+++ b/router/tool_verifier.py
@@ -1,0 +1,95 @@
+"""モデルのツール呼び出し（function calling）サポートを検証する。
+
+Roo Code など function calling を利用するクライアント向けに、
+モデルが正しく tool_calls を返せるかを簡易的に確認する。
+"""
+import copy
+import logging
+
+from adapters.base import (
+    AbstractLLMAdapter,
+    ProviderError,
+    ProviderTimeoutError,
+    RateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+# OpenRouter がツール非対応モデルに返す明示的なエラーメッセージ。
+# これを検出したら「判定保留」ではなく「非対応」として確定させる。
+_NO_TOOL_SUPPORT_MARKERS = (
+    "No endpoints found that support tool use",
+)
+
+# シンプルなツール呼び出しを誘発するテストペイロード。
+# モデルが tool_calls を返せば「対応」と判定する。
+_TEST_PAYLOAD: dict = {
+    "messages": [
+        {
+            "role": "user",
+            "content": (
+                "What is the current weather in Tokyo? "
+                "You must call the get_weather tool to answer."
+            ),
+        }
+    ],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a given city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {
+                            "type": "string",
+                            "description": "City name",
+                        }
+                    },
+                    "required": ["city"],
+                },
+            },
+        }
+    ],
+    "tool_choice": "auto",
+    "max_tokens": 128,
+    "temperature": 0,
+}
+
+
+async def verify_tool_support(
+    adapter: AbstractLLMAdapter, model: str, timeout: float
+) -> bool | None:
+    """モデルがツール呼び出しを返せるか検証する。
+
+    Returns:
+        True:  tool_calls を返した（対応）
+        False: tool_calls を返さなかった（非対応）
+        None:  検証自体が失敗（429/timeout 等）→判定保留、次回起動時に再試行
+    """
+    payload = copy.deepcopy(_TEST_PAYLOAD)
+    try:
+        response = await adapter.chat_completion(payload, model, timeout)
+    except (RateLimitError, ProviderTimeoutError) as exc:
+        logger.info(f"Tool support verify deferred for {model}: {exc}")
+        return None
+    except ProviderError as exc:
+        message = str(exc)
+        if any(marker in message for marker in _NO_TOOL_SUPPORT_MARKERS):
+            logger.info(
+                f"Tool support explicitly unsupported by provider for {model}"
+            )
+            return False
+        logger.info(f"Tool support verify deferred for {model}: {exc}")
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.info(f"Tool support verify deferred for {model}: {exc}")
+        return None
+
+    choices = response.get("choices") or []
+    if not choices:
+        return False
+    message = choices[0].get("message") or {}
+    tool_calls = message.get("tool_calls")
+    return bool(tool_calls)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -56,7 +56,7 @@ if 'router.model_router' not in sys.modules:
     model_router_module = ModuleType('router.model_router')
     
     class ModelRouter:
-        def __init__(self, openrouter_base_url: str, priority_keywords: list, cache_ttl: int = 300):
+        def __init__(self, openrouter_base_url: str, priority_keywords: list, exclude_keywords=None, cache_ttl: int = 300):
             pass
         
         async def get_free_models(self):
@@ -64,6 +64,48 @@ if 'router.model_router' not in sys.modules:
     
     model_router_module.ModelRouter = ModelRouter
     sys.modules['router.model_router'] = model_router_module
+
+# router.tool_support_registry
+if 'router.tool_support_registry' not in sys.modules:
+    tsr_module = ModuleType('router.tool_support_registry')
+
+    class ToolSupportRegistry:
+        def __init__(self, cache_file: str = "tool_support_cache.json"):
+            self._cache = {}
+
+        def get_unverified(self, models):
+            return []
+
+        def mark(self, model, supported):
+            pass
+
+        def is_supported(self, model):
+            return True
+
+        def filter_supported(self, models):
+            return list(models)
+
+        def unsupported_models(self):
+            return []
+
+        def prune(self, current_models):
+            return 0
+
+        def save(self):
+            pass
+
+    tsr_module.ToolSupportRegistry = ToolSupportRegistry
+    sys.modules['router.tool_support_registry'] = tsr_module
+
+# router.tool_verifier
+if 'router.tool_verifier' not in sys.modules:
+    tv_module = ModuleType('router.tool_verifier')
+
+    async def verify_tool_support(adapter, model, timeout):
+        return True
+
+    tv_module.verify_tool_support = verify_tool_support
+    sys.modules['router.tool_verifier'] = tv_module
 
 # router.failover
 if 'router.failover' not in sys.modules:

--- a/tests/test_tool_support_registry.py
+++ b/tests/test_tool_support_registry.py
@@ -1,0 +1,84 @@
+"""ToolSupportRegistry のテスト"""
+import json
+import os
+import sys
+
+# モジュールを強制的に再読み込み（他のテストでのモックの影響を排除）
+for mod in list(sys.modules.keys()):
+    if mod.startswith("adapters.") or mod.startswith("router."):
+        del sys.modules[mod]
+
+from router.tool_support_registry import ToolSupportRegistry
+
+
+class TestToolSupportRegistry:
+    def test_load_missing_file_returns_empty(self, tmp_path):
+        cache_file = tmp_path / "missing.json"
+        registry = ToolSupportRegistry(cache_file=str(cache_file))
+        assert registry._cache == {}
+
+    def test_mark_and_filter(self, tmp_path):
+        cache_file = tmp_path / "cache.json"
+        registry = ToolSupportRegistry(cache_file=str(cache_file))
+        registry.mark("good/model:free", True)
+        registry.mark("bad/model:free", False)
+
+        models = ["good/model:free", "bad/model:free", "unknown/model:free"]
+        filtered = registry.filter_supported(models)
+
+        # unknown は未検証なので楽観的に含まれる
+        assert "good/model:free" in filtered
+        assert "unknown/model:free" in filtered
+        assert "bad/model:free" not in filtered
+
+    def test_get_unverified(self, tmp_path):
+        cache_file = tmp_path / "cache.json"
+        registry = ToolSupportRegistry(cache_file=str(cache_file))
+        registry.mark("known/model:free", True)
+
+        unverified = registry.get_unverified(["known/model:free", "new/model:free"])
+        assert unverified == ["new/model:free"]
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        cache_file = tmp_path / "cache.json"
+        reg1 = ToolSupportRegistry(cache_file=str(cache_file))
+        reg1.mark("a/b:free", True)
+        reg1.mark("c/d:free", False)
+        reg1.save()
+
+        reg2 = ToolSupportRegistry(cache_file=str(cache_file))
+        assert reg2.is_supported("a/b:free") is True
+        assert reg2.is_supported("c/d:free") is False
+        assert reg2.is_supported("unknown:free") is True  # 未検証 = 楽観的
+
+    def test_unsupported_models(self, tmp_path):
+        cache_file = tmp_path / "cache.json"
+        registry = ToolSupportRegistry(cache_file=str(cache_file))
+        registry.mark("a:free", True)
+        registry.mark("b:free", False)
+        registry.mark("c:free", False)
+
+        assert registry.unsupported_models() == ["b:free", "c:free"]
+
+    def test_prune_removes_stale(self, tmp_path):
+        cache_file = tmp_path / "cache.json"
+        registry = ToolSupportRegistry(cache_file=str(cache_file))
+        registry.mark("alive:free", True)
+        registry.mark("stale:free", False)
+
+        pruned = registry.prune(["alive:free"])
+        assert pruned == 1
+        assert "stale:free" not in registry._cache
+        assert "alive:free" in registry._cache
+
+    def test_load_corrupt_file_returns_empty(self, tmp_path):
+        cache_file = tmp_path / "corrupt.json"
+        cache_file.write_text("not json", encoding="utf-8")
+        registry = ToolSupportRegistry(cache_file=str(cache_file))
+        assert registry._cache == {}
+
+    def test_load_unexpected_format_returns_empty(self, tmp_path):
+        cache_file = tmp_path / "wrong.json"
+        cache_file.write_text(json.dumps(["list", "not", "dict"]), encoding="utf-8")
+        registry = ToolSupportRegistry(cache_file=str(cache_file))
+        assert registry._cache == {}

--- a/tests/test_tool_verifier.py
+++ b/tests/test_tool_verifier.py
@@ -1,0 +1,118 @@
+"""verify_tool_support のテスト"""
+import sys
+import pytest
+from unittest.mock import AsyncMock
+
+# モジュールを強制的に再読み込み
+for mod in list(sys.modules.keys()):
+    if mod.startswith("adapters.") or mod.startswith("router."):
+        del sys.modules[mod]
+
+from adapters.base import ProviderError, ProviderTimeoutError, RateLimitError
+from router.tool_verifier import verify_tool_support
+
+
+class _FakeAdapter:
+    def __init__(self, response=None, exc=None):
+        self._response = response
+        self._exc = exc
+        self.chat_completion = AsyncMock(side_effect=self._side_effect)
+        self.chat_completion_stream = AsyncMock()
+
+    async def _side_effect(self, payload, model, timeout):
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+class TestVerifyToolSupport:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_tool_calls_present(self):
+        adapter = _FakeAdapter(
+            response={
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": '{"city": "Tokyo"}',
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+        )
+        result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_tool_calls(self):
+        adapter = _FakeAdapter(
+            response={
+                "choices": [
+                    {"message": {"role": "assistant", "content": "I would call..."}}
+                ]
+            }
+        )
+        result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_empty_choices(self):
+        adapter = _FakeAdapter(response={"choices": []})
+        result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_rate_limit(self):
+        adapter = _FakeAdapter(exc=RateLimitError("429"))
+        result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_timeout(self):
+        adapter = _FakeAdapter(exc=ProviderTimeoutError("timeout"))
+        result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_provider_error(self):
+        adapter = _FakeAdapter(exc=ProviderError("500"))
+        result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_explicit_no_tool_support_error(self):
+        """OpenRouter が 404 で 'No endpoints found that support tool use' を返した場合は非対応確定"""
+        exc = ProviderError(
+            'OpenRouter 404 (x/y:free): {"error":{"message":"No endpoints found '
+            'that support tool use. Try disabling ..."}}'
+        )
+        adapter = _FakeAdapter(exc=exc)
+        result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_sends_tools_in_payload(self):
+        captured = {}
+
+        class _CaptureAdapter:
+            async def chat_completion(self, payload, model, timeout):
+                captured["payload"] = payload
+                captured["model"] = model
+                return {"choices": [{"message": {"tool_calls": [{"id": "1"}]}}]}
+
+            async def chat_completion_stream(self, payload, model, timeout):
+                yield b""
+
+        await verify_tool_support(_CaptureAdapter(), "test:free", timeout=5.0)
+        assert "tools" in captured["payload"]
+        assert captured["payload"]["tools"][0]["function"]["name"] == "get_weather"
+        assert captured["model"] == "test:free"


### PR DESCRIPTION
## 概要

OpenRouter の無料モデルのうち、function calling（ツール呼び出し）に対応していないものを起動時に自動検出し、以降のリクエストから除外する仕組みを追加する。併せて優先度ルールを整理する。

## 背景

- Roo Code 等の function calling クライアントから本プロキシを利用した際、ツール呼び出し非対応モデルが選ばれるとエージェント動作が破綻していた。
- モデル名固定での回避はベンダーに偏り、OpenRouter のモデル更新に弱い。
- メンテナンスフリーで自動的に非対応モデルを検出・除外する仕組みが必要だった。

## 変更内容

### コミット1: feat: ツール呼び出し対応の自動検証機能を追加

- \`router/tool_verifier.py\`: \`get_weather\` 相当の簡易 function を呼ばせ、\`tool_calls\` が返るか判定
- \`router/tool_support_registry.py\`: 判定結果を \`tool_support_cache.json\` に永続化
- \`main.py\`: lifespan で未検証モデルのみ検証 → 結果をキャッシュ。リクエスト時は非対応モデルをフィルタ
- OpenRouter の 404 + \"No endpoints found that support tool use\" を明示的非対応として確定
- 429 / timeout は判定保留（次回起動時に再試行）
- 未検証モデルは楽観的に許可（API 不調による誤除外を防止）

### コミット2: chore: priority_keywords の優先度ルールを整理

- \`nano\` / \`mini\` / \`lite\` を最優先マッチで低優先度化
- 50-100B を最優先、30-50B、100B+、10-20B の順に変更
- 70B 以上を優先することで指示追従能力を確保
- モデル名に依存せずパラメータ数ベースでの判定に統一

## 動作確認

- \`pytest tests/\`: 60 件全通過
- 実機起動 → 10 モデルが自動除外されることを確認
- Roo Code からのコミット操作が正常に完了（日本語コミットメッセージ含む）

## 設定項目（新規）

| 項目 | デフォルト | 説明 |
|---|---|---|
| \`verify_tool_support\` | \`true\` | 起動時に新規モデルのツール対応を検証 |
| \`verify_timeout_seconds\` | \`15\` | 検証リクエストのタイムアウト |
| \`tool_support_cache_file\` | \`tool_support_cache.json\` | キャッシュファイル名 |

## 備考

- \`tool_support_cache.json\` は \`.gitignore\` 対象
- README に設定項目と動作説明を追記済み