### PR TITLE
feat: 429クールダウン機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ curl -X POST http://127.0.0.1:4141/v1/chat/completions \
 | `verify_tool_support` | 起動時に新規モデルのツール呼び出し対応を検証する（デフォルト `true`） |
 | `verify_timeout_seconds` | 検証リクエストのタイムアウト（秒） |
 | `tool_support_cache_file` | 検証結果のキャッシュファイル名 |
+| `rate_limit_cooldown_seconds` | 429 を返したモデルをスキップする秒数（デフォルト `60`、`0` で無効化） |
 
 ### ツール呼び出し検証の動作
 

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
   "verify_tool_support": true,
   "verify_timeout_seconds": 15,
   "tool_support_cache_file": "tool_support_cache.json",
+  "rate_limit_cooldown_seconds": 60,
   "exclude_keywords": ["dolphin", "liquid", "arcee"],
   "priority_keywords": [
     {"keywords": ["nano", "mini", "lite"], "priority": 98},

--- a/main.py
+++ b/main.py
@@ -115,6 +115,7 @@ async def chat_completions(request: Request):
         local_adapter=ollama_adapter,
         local_model=config["ollama_model"],
         timeout=config["timeout_seconds"],
+        cooldown_seconds=float(config.get("rate_limit_cooldown_seconds", 60)),
     )
 
     result = await failover.execute_with_failover(payload, models, stream)

--- a/router/failover.py
+++ b/router/failover.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import AsyncIterator
 
 from adapters.base import (
@@ -14,17 +15,52 @@ logger = logging.getLogger(__name__)
 class FailoverRouter:
     """429 / タイムアウト発生時に次のモデルへ自動切替を行う"""
 
+    # 429 を返したモデルのクールダウン期限 (UNIX秒)。
+    # FailoverRouter はリクエストごとに再インスタンス化されるため
+    # クラス変数でプロセス内共有する（再起動でリセット）
+    _cooldown_until: dict[str, float] = {}
+
     def __init__(
         self,
         cloud_adapter: AbstractLLMAdapter,
         local_adapter: AbstractLLMAdapter,
         local_model: str,
         timeout: float,
+        cooldown_seconds: float = 60.0,
     ) -> None:
         self._cloud_adapter = cloud_adapter
         self._local_adapter = local_adapter
         self._local_model = local_model
         self._timeout = timeout
+        self._cooldown_seconds = cooldown_seconds
+
+    def _is_cooling_down(self, model: str) -> bool:
+        """モデルがクールダウン期間中かを判定"""
+        expires = self._cooldown_until.get(model)
+        if expires is None:
+            return False
+        if time.monotonic() >= expires:
+            # 期限切れエントリを掃除
+            self._cooldown_until.pop(model, None)
+            return False
+        return True
+
+    def _mark_cooldown(self, model: str) -> None:
+        """モデルを cooldown_seconds 秒間スキップ対象にする"""
+        if self._cooldown_seconds <= 0:
+            return
+        self._cooldown_until[model] = time.monotonic() + self._cooldown_seconds
+        logger.info(
+            f"Model {model} is on cooldown for {self._cooldown_seconds:.0f}s"
+        )
+
+    def _filter_available(self, models: list[str]) -> list[str]:
+        """クールダウン中のモデルを除外"""
+        available = [m for m in models if not self._is_cooling_down(m)]
+        skipped = len(models) - len(available)
+        if skipped:
+            logger.info(f"Skipping {skipped} model(s) on cooldown")
+        return available
 
     async def execute_with_failover(
         self,
@@ -43,14 +79,20 @@ class FailoverRouter:
     ) -> dict:
         """非ストリーミングリクエストのFailover処理"""
         last_error: Exception | None = None
+        available_models = self._filter_available(models)
 
-        for model in models:
+        for model in available_models:
             try:
                 logger.info(f"Trying model: {model}")
                 return await self._cloud_adapter.chat_completion(
                     payload, model, self._timeout
                 )
-            except (RateLimitError, ProviderTimeoutError) as exc:
+            except RateLimitError as exc:
+                logger.warning(f"Model {model} failed: {exc}")
+                self._mark_cooldown(model)
+                last_error = exc
+                continue
+            except ProviderTimeoutError as exc:
                 logger.warning(f"Model {model} failed: {exc}")
                 last_error = exc
                 continue
@@ -75,8 +117,9 @@ class FailoverRouter:
     ) -> AsyncIterator[bytes]:
         """ストリーミングリクエストのFailover処理"""
         last_error: Exception | None = None
+        available_models = self._filter_available(models)
 
-        for model in models:
+        for model in available_models:
             try:
                 logger.info(f"Trying model: {model}")
                 stream_gen = self._cloud_adapter.chat_completion_stream(
@@ -85,7 +128,12 @@ class FailoverRouter:
                 async for chunk in stream_gen:
                     yield chunk
                 return
-            except (RateLimitError, ProviderTimeoutError) as exc:
+            except RateLimitError as exc:
+                logger.warning(f"Model {model} failed: {exc}")
+                self._mark_cooldown(model)
+                last_error = exc
+                continue
+            except ProviderTimeoutError as exc:
                 logger.warning(f"Model {model} failed: {exc}")
                 last_error = exc
                 continue

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -16,6 +16,14 @@ from adapters.base import (
 from router.failover import FailoverRouter
 
 
+@pytest.fixture(autouse=True)
+def _reset_cooldown():
+    """各テスト前後でクラス変数のクールダウン状態をリセット"""
+    FailoverRouter._cooldown_until.clear()
+    yield
+    FailoverRouter._cooldown_until.clear()
+
+
 class TestFailoverRouter:
     """FailoverRouter のテスト"""
 
@@ -225,3 +233,181 @@ class TestFailoverRouter:
         
         assert result == {"result": "success"}
         assert cloud_adapter.chat_completion.call_count == 2
+
+
+class TestRateLimitCooldown:
+    """429 クールダウン機能のテスト"""
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_model_registered_to_cooldown(self):
+        """429 を受けたモデルは cooldown リストに登録される"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(
+            side_effect=[RateLimitError("429"), {"result": "success"}]
+        )
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+            cooldown_seconds=60.0,
+        )
+
+        await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+
+        assert "model1" in FailoverRouter._cooldown_until
+        assert "model2" not in FailoverRouter._cooldown_until
+
+    @pytest.mark.asyncio
+    async def test_cooldown_model_is_skipped(self):
+        """cooldown 中のモデルはリクエスト対象から除外される"""
+        import time as _time
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(return_value={"result": "success"})
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+            cooldown_seconds=60.0,
+        )
+
+        FailoverRouter._cooldown_until["model1"] = _time.monotonic() + 60.0
+
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+
+        assert result == {"result": "success"}
+        assert cloud_adapter.chat_completion.call_count == 1
+        called_model = cloud_adapter.chat_completion.call_args_list[0][0][1]
+        assert called_model == "model2"
+
+    @pytest.mark.asyncio
+    async def test_expired_cooldown_entry_is_retried(self):
+        """cooldown 期限切れのモデルは再試行対象に戻る"""
+        import time as _time
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(return_value={"result": "success"})
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+            cooldown_seconds=60.0,
+        )
+
+        FailoverRouter._cooldown_until["model1"] = _time.monotonic() - 1.0
+
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1"],
+            stream=False,
+        )
+
+        assert result == {"result": "success"}
+        assert cloud_adapter.chat_completion.call_count == 1
+        assert "model1" not in FailoverRouter._cooldown_until
+
+    @pytest.mark.asyncio
+    async def test_all_models_cooldown_falls_back_to_local(self):
+        """全モデルが cooldown 中の場合はローカルへフォールバック"""
+        import time as _time
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock()
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+        local_adapter.chat_completion = AsyncMock(return_value={"result": "local"})
+
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+            cooldown_seconds=60.0,
+        )
+
+        now = _time.monotonic()
+        FailoverRouter._cooldown_until["model1"] = now + 60.0
+        FailoverRouter._cooldown_until["model2"] = now + 60.0
+
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+
+        assert result == {"result": "local"}
+        assert cloud_adapter.chat_completion.call_count == 0
+        assert local_adapter.chat_completion.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cooldown_disabled_when_zero(self):
+        """cooldown_seconds=0 のとき cooldown は登録されない"""
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion = AsyncMock(
+            side_effect=[RateLimitError("429"), {"result": "success"}]
+        )
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+            cooldown_seconds=0.0,
+        )
+
+        await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=False,
+        )
+
+        assert FailoverRouter._cooldown_until == {}
+
+    @pytest.mark.asyncio
+    async def test_stream_rate_limited_model_registered_to_cooldown(self):
+        """ストリーミング時も 429 で cooldown 登録される"""
+        async def failing_stream():
+            raise RateLimitError("429")
+            yield  # pragma: no cover
+
+        async def ok_stream():
+            yield b"data: chunk\n\n"
+
+        cloud_adapter = MagicMock(spec=AbstractLLMAdapter)
+        cloud_adapter.chat_completion_stream = MagicMock(
+            side_effect=[failing_stream(), ok_stream()]
+        )
+        local_adapter = MagicMock(spec=AbstractLLMAdapter)
+
+        router = FailoverRouter(
+            cloud_adapter=cloud_adapter,
+            local_adapter=local_adapter,
+            local_model="phi3.5:latest",
+            timeout=20.0,
+            cooldown_seconds=60.0,
+        )
+
+        result = await router.execute_with_failover(
+            payload={"messages": []},
+            models=["model1", "model2"],
+            stream=True,
+        )
+
+        chunks = [chunk async for chunk in result]
+        assert chunks == [b"data: chunk\n\n"]
+        assert "model1" in FailoverRouter._cooldown_until
+        assert "model2" not in FailoverRouter._cooldown_until


### PR DESCRIPTION
## 概要

FailoverRouter が毎リクエストで同じ 429 モデルを無駄打ちするのを回避するため、レート制限クールダウン機能を追加しました。

## 変更内容

- **`router/failover.py`**
  - `RateLimitError` を受けたモデルを `cooldown_seconds` 秒間スキップ
  - 状態は `_cooldown_until` クラス変数でプロセス内共有（再起動でリセット）
  - 期限切れエントリは自動で掃除
  - ストリーミング / 非ストリーミング両対応
  - 全モデルが cooldown 中の場合は従来通り Ollama へフォールバック
- **\`config.json\`**: \`rate_limit_cooldown_seconds\`（デフォルト \`60\`、\`0\` で無効化）を追加
- **\`main.py\`**: 設定値を FailoverRouter に渡す
- **\`README.md\`**: 設定項目の説明を追記

## テスト

\`tests/test_failover.py\` に \`TestRateLimitCooldown\` を追加（6 ケース）：

- 429 モデルが cooldown に登録される
- cooldown 中のモデルがスキップされる
- 期限切れエントリは再試行対象に戻る
- 全モデル cooldown 時は Ollama にフォールバック
- \`cooldown_seconds=0\` のとき無効化される
- ストリーミング時も cooldown 登録される

\`pytest\` 全 66 件合格を確認済み。

## 設計上の注意

\`FailoverRouter\` はリクエストごとに再インスタンス化されるため、cooldown 状態はクラス変数で共有しています。再起動で状態はリセットされます（要件通り）。