### PR TITLE
feat: 同owner配下の他リポ参照をビルトインでblockする機密情報ガードを追加

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -51,6 +51,30 @@ chmod +x .githooks/pre-commit .githooks/pre-push .githooks/commit-msg .githooks/
 
 ローカル install は **必須ではない** が、CI 待ちなく早期に検出できるため開発体験向上に寄与する。
 
+## 自リポジトリ外への非公開情報漏洩防止（ビルトイン）
+
+**作業中のリポジトリ** から動的に `owner` を検出し、**同 owner 配下の「他リポジトリ」への参照を自動的に block** します。パターン定義ファイルへの追記は不要で、新しいリポジトリを作成しても自動で保護対象になります。
+
+### 動作
+
+- 自リポ情報の取得源
+  - hook 実行時: `git config --get remote.origin.url` から `owner/repo` を抽出
+  - workflow 実行時: `$GITHUB_REPOSITORY` / `context.repo`
+- スキャン前に自リポ参照（`owner/repo`、`owner/repo#N`、`https://github.com/owner/repo/...`）を placeholder にマスク
+- マスク後のテキストに `${owner}/<任意>` 形式が残れば「同 owner 他リポ参照」として block
+- 他 owner のリポ参照（OSS 等）は block しない（既存 warn-regex で警告のみ）
+
+### 判定例（作業中リポが `acme/site-a` の場合）
+
+| 書いた内容 | 判定 |
+|---|---|
+| `acme/site-a`, `acme/site-a#42` | 許可（自リポ） |
+| `https://github.com/acme/site-a/pull/42` | 許可（自リポ） |
+| `acme/site-b`, `acme/internal-tools` | block（同 owner 他リポ） |
+| `torvalds/linux`, `https://github.com/octocat/hello-world` | 許可（警告のみ） |
+
+自リポ以外の `owner/repo` を個別に許可/拒否したい場合のみ `sensitive-patterns.txt` に `literal:owner/repo` を追記してください。
+
 ## 機密情報・環境固有情報の多層ガード
 
 Git/GitHub に永続化される全ての文字列への機密情報混入を、以下の層で防ぐ:

--- a/.githooks/lib/scan-sensitive.sh
+++ b/.githooks/lib/scan-sensitive.sh
@@ -9,9 +9,79 @@
 #   scan_sensitive_text "<text>" ... 文字列を走査。block パターン検出で 1 を返す。
 #   scan_sensitive_file <path>   ... ファイル内容を走査。block パターン検出で 1 を返す。
 #
+# ビルトイン（パターン定義不要）:
+#   - 作業中リポから自 owner/repo を自動検出
+#   - 自リポ参照 (owner/repo, owner/repo#N, URL) はスキャン対象から除外
+#   - 同 owner 配下の他リポ参照は block（非公開リポの存在露出を防ぐ）
+#
 # 警告（warn-regex）は stderr に出力するが戻り値に影響しない。
 
 _SENSITIVE_PATTERNS_FILE="$(git rev-parse --show-toplevel 2>/dev/null)/.githooks/sensitive-patterns.txt"
+
+# 正規表現メタ文字のエスケープ（POSIX sed 向け）
+_escape_regex() {
+    printf '%s' "$1" | sed 's/[][\.*^$|+?(){}/]/\\&/g'
+}
+
+# 自リポジトリ情報の自動検出
+#   優先1: 環境変数 GITHUB_REPOSITORY（GitHub Actions 実行時に自動セット）
+#   優先2: git remote origin URL から owner/repo を抽出
+# 返却: "owner/repo" 形式（取得失敗時は空文字）
+_detect_self_repo() {
+    if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+        printf '%s' "$GITHUB_REPOSITORY"
+        return 0
+    fi
+    _url=$(git config --get remote.origin.url 2>/dev/null || true)
+    [ -z "$_url" ] && return 0
+    printf '%s' "$_url" | sed -E 's#^.*github\.com[:/]([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(\.git)?/?$#\1#'
+}
+
+# 入力テキストから自リポ参照（owner/name 形式と URL 形式）を placeholder にマスクして出力
+#   自リポが検出できない場合は入力をそのまま返す
+_mask_self_repo_refs() {
+    _text="$1"
+    _self_repo=$(_detect_self_repo)
+    if [ -z "$_self_repo" ]; then
+        printf '%s' "$_text"
+        return 0
+    fi
+    case "$_self_repo" in
+        */*) : ;;
+        *) printf '%s' "$_text"; return 0 ;;
+    esac
+    _self_owner_re=$(_escape_regex "${_self_repo%%/*}")
+    _self_name_re=$(_escape_regex "${_self_repo##*/}")
+    printf '%s' "$_text" \
+        | sed -E "s#(^|[^A-Za-z0-9_.-])${_self_owner_re}/${_self_name_re}([^A-Za-z0-9_.-]|\$)#\\1[SELF]\\2#g" \
+        | sed -E "s#https?://github\\.com/${_self_owner_re}/${_self_name_re}([#/?][^[:space:]]*)?#[SELF_URL]#g"
+}
+
+# ビルトイン: 自 owner 配下の他リポ参照を検出（block）
+#   $1: 自リポ参照マスク済みテキスト
+# 戻り値: 0 = 問題なし / 1 = 他リポ参照検出
+_scan_builtin_same_owner() {
+    _masked="$1"
+    _self_repo=$(_detect_self_repo)
+    [ -z "$_self_repo" ] && return 0
+    case "$_self_repo" in
+        */*) : ;;
+        *) return 0 ;;
+    esac
+    _self_owner="${_self_repo%%/*}"
+    _self_owner_re=$(_escape_regex "$_self_owner")
+
+    _hit=$(printf '%s\n' "$_masked" \
+        | grep -nE "(^|[^A-Za-z0-9_.-])${_self_owner_re}/[A-Za-z0-9_.-]+|https?://github\\.com/${_self_owner_re}/[A-Za-z0-9_.-]+" 2>/dev/null \
+        | head -3)
+
+    if [ -n "$_hit" ]; then
+        echo "  [block] builtin: 同 owner '$_self_owner' 配下の他リポジトリ参照は禁止" >&2
+        echo "$_hit" | sed 's/^/    /' >&2
+        return 1
+    fi
+    return 0
+}
 
 _scan_sensitive_core() {
     # $1: mode = "text" | "file"
@@ -20,7 +90,29 @@ _scan_sensitive_core() {
     _target="$2"
     _found=0
 
-    [ ! -f "$_SENSITIVE_PATTERNS_FILE" ] && return 0
+    # --- 入力取得（file/text どちらも文字列として扱い、自リポ参照をマスクする） ---
+    if [ "$_mode" = "file" ]; then
+        if [ -f "$_target" ]; then
+            _content=$(cat "$_target" 2>/dev/null)
+        else
+            _content=""
+        fi
+        _loc_suffix=" in $_target"
+    else
+        _content="$_target"
+        _loc_suffix=""
+    fi
+    _masked=$(_mask_self_repo_refs "$_content")
+
+    # --- ビルトイン: 自 owner 配下の他リポ参照検出 ---
+    if [ -n "$_masked" ]; then
+        if ! _scan_builtin_same_owner "$_masked"; then
+            [ -n "$_loc_suffix" ] && echo "   (file:$_target)" >&2
+            _found=1
+        fi
+    fi
+
+    [ ! -f "$_SENSITIVE_PATTERNS_FILE" ] && return $_found
 
     while IFS= read -r _line || [ -n "$_line" ]; do
         case "$_line" in
@@ -32,38 +124,22 @@ _scan_sensitive_core() {
         [ "$_type" = "$_line" ] && continue
 
         _hit=""
-        if [ "$_mode" = "file" ]; then
-            case "$_type" in
-                literal)
-                    _hit=$(grep -nF -- "$_pattern" "$_target" 2>/dev/null | head -3)
-                    ;;
-                regex)
-                    _hit=$(grep -nE -- "$_pattern" "$_target" 2>/dev/null | head -3)
-                    ;;
-                warn-regex)
-                    if grep -qE -- "$_pattern" "$_target" 2>/dev/null; then
-                        echo "  [warn] pattern='$_pattern' in $_target" >&2
-                    fi
-                    ;;
-            esac
-        else
-            case "$_type" in
-                literal)
-                    _hit=$(printf '%s\n' "$_target" | grep -nF -- "$_pattern" 2>/dev/null | head -3)
-                    ;;
-                regex)
-                    _hit=$(printf '%s\n' "$_target" | grep -nE -- "$_pattern" 2>/dev/null | head -3)
-                    ;;
-                warn-regex)
-                    if printf '%s\n' "$_target" | grep -qE -- "$_pattern" 2>/dev/null; then
-                        echo "  [warn] pattern='$_pattern'" >&2
-                    fi
-                    ;;
-            esac
-        fi
+        case "$_type" in
+            literal)
+                _hit=$(printf '%s\n' "$_masked" | grep -nF -- "$_pattern" 2>/dev/null | head -3)
+                ;;
+            regex)
+                _hit=$(printf '%s\n' "$_masked" | grep -nE -- "$_pattern" 2>/dev/null | head -3)
+                ;;
+            warn-regex)
+                if printf '%s\n' "$_masked" | grep -qE -- "$_pattern" 2>/dev/null; then
+                    echo "  [warn] pattern='$_pattern'${_loc_suffix}" >&2
+                fi
+                ;;
+        esac
 
         if [ -n "$_hit" ]; then
-            echo "  [block] type=$_type pattern='$_pattern'" >&2
+            echo "  [block] type=$_type pattern='$_pattern'${_loc_suffix}" >&2
             echo "$_hit" | sed 's/^/    /' >&2
             _found=1
         fi

--- a/.githooks/sensitive-patterns.txt
+++ b/.githooks/sensitive-patterns.txt
@@ -36,7 +36,10 @@ regex:(^|[^0-9.])172\.(1[6-9]|2[0-9]|3[01])\.[0-9]{1,3}\.[0-9]{1,3}([^0-9.]|$)
 # 社内 SaaS サブドメイン:
 #   regex:https?://[a-z0-9-]+\.slack\.com/
 
-# --- GitHub 他リポジトリ参照（汎用・警告のみ・誤検知防止） ---
-# 具体的な owner/repo を block したい場合は上記の literal で明示追記してください。
+# --- GitHub 他リポジトリ参照（第三者 owner 配下・警告のみ・誤検知防止） ---
+# 自リポ (owner/repo) の参照は scan-sensitive.sh / sensitive-info-guard.yml の
+# ビルトインマスク処理により除外されるため、ここでの警告対象にはなりません。
+# また、同 owner 配下の他リポジトリ参照はビルトインで block されるため、
+# 以下の warn-regex は主に第三者 (OSS 等) の owner/repo 参照に反応します。
 warn-regex:[A-Za-z0-9_-]+/[A-Za-z0-9_.-]+#[0-9]+
 warn-regex:https?://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+

--- a/.github/workflows/sensitive-info-guard.yml
+++ b/.github/workflows/sensitive-info-guard.yml
@@ -49,12 +49,32 @@ jobs:
             const cm = context.payload.comment;
             if (cm) texts.push(['comment', cm.body ?? '']);
 
+            // --- 自リポ参照マスク & ビルトイン: 同owner他リポ参照検出 ---
+            const selfOwner = context.repo.owner;
+            const selfName = context.repo.repo;
+            const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const ownerRe = esc(selfOwner);
+            const nameRe = esc(selfName);
+            const maskSelf = (text) => text
+              .replace(new RegExp(`(^|[^A-Za-z0-9_.-])${ownerRe}/${nameRe}([^A-Za-z0-9_.-]|$)`, 'g'), '$1[SELF]$2')
+              .replace(new RegExp(`https?://github\\.com/${ownerRe}/${nameRe}(?:[#/?][^\\s]*)?`, 'g'), '[SELF_URL]');
+            const builtinPattern = new RegExp(
+              `(?:^|[^A-Za-z0-9_.-])${ownerRe}/[A-Za-z0-9_.-]+|https?://github\\.com/${ownerRe}/[A-Za-z0-9_.-]+`
+            );
+
             const blocks = [];
             const warns = [];
 
-            for (const { type, pattern } of rules) {
-              for (const [loc, text] of texts) {
-                if (!text) continue;
+            for (const [loc, rawText] of texts) {
+              if (!rawText) continue;
+              const text = maskSelf(rawText);
+
+              // ビルトイン: 同 owner 配下の他リポ参照
+              if (builtinPattern.test(text)) {
+                blocks.push(`${loc}: [builtin] 同 owner '${selfOwner}' 配下の他リポジトリ参照は禁止`);
+              }
+
+              for (const { type, pattern } of rules) {
                 if (type === 'literal') {
                   if (text.includes(pattern)) {
                     blocks.push(`${loc}: [literal] ${pattern}`);


### PR DESCRIPTION
## 概要

PR本文・コミットメッセージ等で **作業中リポジトリと同じ owner 配下の他リポジトリ参照を物理的に block** するビルトイン機構を `.githooks/` と `sensitive-info-guard.yml` に追加する。`template` リポジトリで先行実装した内容を本リポジトリへ横展開する。

従来は `sensitive-patterns.txt` に個別 `literal:owner/repo` を追記する運用だったが、新規リポジトリが網羅されない・組織名を設定ファイルに残す必要があるといった課題があった。作業中リポから `owner/repo` を動的検出することで、追加設定なしでも常に最新のリポジトリ一覧が保護対象となる。

## 変更内容

- `.githooks/lib/scan-sensitive.sh`
  - `_detect_self_repo`: `$GITHUB_REPOSITORY` または git remote origin URL から自リポ `owner/repo` を抽出
  - `_mask_self_repo_refs`: 自リポ参照（`owner/repo`, `owner/repo#N`, URL 形式）をスキャン前に placeholder へ置換
  - `_scan_builtin_same_owner`: マスク後に残った `${owner}/<任意>` 形式を block
  - 既存 `literal` / `regex` / `warn-regex` 照合もマスク済みテキストを使用するよう統一
- `.github/workflows/sensitive-info-guard.yml`
  - JS 側にも同等のマスク処理とビルトインチェックを実装（`context.repo.owner` / `context.repo.repo` を利用）
- `.githooks/sensitive-patterns.txt`
  - コメントを更新。ビルトインで同 owner 他リポは block される旨を明記
- `.githooks/README.md`
  - 「自リポジトリ外への非公開情報漏洩防止（ビルトイン）」セクションを追加

## テスト

- template リポジトリ PR で全チェック PASS 済（シェル12ケース / JS 12ケース単体テスト、Sensitive Info Guard セルフテスト含む）
- 本リポジトリでも本 PR 自身が `Sensitive Info Guard/scan` のセルフテスト対象となる
- 判定の挙動（作業中リポ owner/name を自動検出し、他リポ参照は block、自リポ参照と第三者 owner 参照は通過）はシェル側 / ワークフロー側とも同一ロジックで実装

## 備考

- 本 PR はテンプレート先行実装の横展開であり、4ファイルの内容は完全一致する。
- `sensitive-patterns.txt` に組織名ハードコードは行わない（動的検出方式）。
