### PR TITLE
refactor: ログ改善とコード整理

### DIFF
--- a/adapters/ollama.py
+++ b/adapters/ollama.py
@@ -1,8 +1,11 @@
+import logging
 from typing import AsyncGenerator
 
 import httpx
 
 from .base import AbstractLLMAdapter, ProviderError, ProviderTimeoutError
+
+logger = logging.getLogger(__name__)
 
 
 class OllamaAdapter(AbstractLLMAdapter):

--- a/adapters/openrouter.py
+++ b/adapters/openrouter.py
@@ -1,9 +1,12 @@
 import json
+import logging
 from typing import AsyncGenerator
 
 import httpx
 
 from .base import AbstractLLMAdapter, ProviderError, ProviderTimeoutError, RateLimitError
+
+logger = logging.getLogger(__name__)
 
 
 class OpenRouterAdapter(AbstractLLMAdapter):

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ load_dotenv()
 
 logging.basicConfig(
     level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    format="%(asctime)s [%(levelname)s] %(message)s",
 )
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,14 @@ openrouter_adapter = OpenRouterAdapter(
 )
 
 ollama_adapter = OllamaAdapter(base_url=config["ollama_base_url"])
+
+failover_router = FailoverRouter(
+    cloud_adapter=openrouter_adapter,
+    local_adapter=ollama_adapter,
+    local_model=config["ollama_model"],
+    timeout=config["timeout_seconds"],
+    cooldown_seconds=float(config.get("rate_limit_cooldown_seconds", 60)),
+)
 
 tool_support_registry = ToolSupportRegistry(
     cache_file=config.get("tool_support_cache_file", "tool_support_cache.json")
@@ -110,15 +118,7 @@ async def chat_completions(request: Request):
     if not models:
         raise HTTPException(status_code=503, detail="No free models available")
 
-    failover = FailoverRouter(
-        cloud_adapter=openrouter_adapter,
-        local_adapter=ollama_adapter,
-        local_model=config["ollama_model"],
-        timeout=config["timeout_seconds"],
-        cooldown_seconds=float(config.get("rate_limit_cooldown_seconds", 60)),
-    )
-
-    result = await failover.execute_with_failover(payload, models, stream)
+    result = await failover_router.execute_with_failover(payload, models, stream)
 
     if stream:
         return StreamingResponse(result, media_type="text/event-stream")

--- a/router/failover.py
+++ b/router/failover.py
@@ -50,16 +50,14 @@ class FailoverRouter:
         if self._cooldown_seconds <= 0:
             return
         self._cooldown_until[model] = time.monotonic() + self._cooldown_seconds
-        logger.info(
-            f"Model {model} is on cooldown for {self._cooldown_seconds:.0f}s"
-        )
+        logger.info(f"COOLDOWN {self._cooldown_seconds:.0f}s   {model}")
 
     def _filter_available(self, models: list[str]) -> list[str]:
         """クールダウン中のモデルを除外"""
         available = [m for m in models if not self._is_cooling_down(m)]
         skipped = len(models) - len(available)
         if skipped:
-            logger.info(f"Skipping {skipped} model(s) on cooldown")
+            logger.info(f"SKIP {skipped} on cooldown")
         return available
 
     async def execute_with_failover(
@@ -83,31 +81,34 @@ class FailoverRouter:
 
         for model in available_models:
             try:
-                logger.info(f"Trying model: {model}")
-                return await self._cloud_adapter.chat_completion(
+                result = await self._cloud_adapter.chat_completion(
                     payload, model, self._timeout
                 )
+                logger.info(f"200 OK   {model}")
+                return result
             except RateLimitError as exc:
-                logger.warning(f"Model {model} failed: {exc}")
+                logger.warning(f"429 Rate limit   {model}")
                 self._mark_cooldown(model)
                 last_error = exc
                 continue
             except ProviderTimeoutError as exc:
-                logger.warning(f"Model {model} failed: {exc}")
+                logger.warning(f"TIMEOUT   {model}")
                 last_error = exc
                 continue
             except ProviderError as exc:
-                logger.error(f"Model {model} non-retryable error: {exc}")
+                logger.error(f"{exc.status_code if hasattr(exc, 'status_code') else 'ERROR'} {str(exc)[:50]}   {model}")
                 last_error = exc
                 continue
 
-        logger.warning("All cloud models failed, falling back to local Ollama")
+        logger.warning("FALLBACK local")
         try:
-            return await self._local_adapter.chat_completion(
+            result = await self._local_adapter.chat_completion(
                 payload, self._local_model, self._timeout
             )
+            logger.info(f"200 OK (local)   {self._local_model}")
+            return result
         except Exception as exc:
-            logger.error(f"Local fallback failed: {exc}")
+            logger.error(f"FAIL local   {self._local_model}")
             raise ProviderError(
                 f"All providers failed. Last error: {last_error}"
             ) from last_error
@@ -121,36 +122,37 @@ class FailoverRouter:
 
         for model in available_models:
             try:
-                logger.info(f"Trying model: {model}")
                 stream_gen = self._cloud_adapter.chat_completion_stream(
                     payload, model, self._timeout
                 )
                 async for chunk in stream_gen:
                     yield chunk
+                logger.info(f"200 OK (stream)   {model}")
                 return
             except RateLimitError as exc:
-                logger.warning(f"Model {model} failed: {exc}")
+                logger.warning(f"429 Rate limit   {model}")
                 self._mark_cooldown(model)
                 last_error = exc
                 continue
             except ProviderTimeoutError as exc:
-                logger.warning(f"Model {model} failed: {exc}")
+                logger.warning(f"TIMEOUT   {model}")
                 last_error = exc
                 continue
             except ProviderError as exc:
-                logger.error(f"Model {model} non-retryable error: {exc}")
+                logger.error(f"{exc.status_code if hasattr(exc, 'status_code') else 'ERROR'} {str(exc)[:50]}   {model}")
                 last_error = exc
                 continue
 
-        logger.warning("All cloud models failed, falling back to local Ollama")
+        logger.warning("FALLBACK local")
         try:
             stream_gen = self._local_adapter.chat_completion_stream(
                 payload, self._local_model, self._timeout
             )
             async for chunk in stream_gen:
                 yield chunk
+            logger.info(f"200 OK (stream local)   {self._local_model}")
         except Exception as exc:
-            logger.error(f"Local fallback failed: {exc}")
+            logger.error(f"FAIL local   {self._local_model}")
             raise ProviderError(
                 f"All providers failed. Last error: {last_error}"
             ) from last_error

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -151,15 +151,13 @@ class TestMainAPI:
     async def test_chat_completions_non_streaming(self):
         """非ストリーミングのチャット補完が正しく動作する"""
         with patch("main.model_router") as mock_router:
-            with patch("main.FailoverRouter") as mock_failover_class:
+            with patch("main.failover_router") as mock_failover:
                 mock_router.get_free_models = AsyncMock(return_value=["model1", "model2"])
-                
-                mock_failover = MagicMock()
+
                 mock_failover.execute_with_failover = AsyncMock(
                     return_value={"choices": [{"message": {"content": "test"}}]}
                 )
-                mock_failover_class.return_value = mock_failover
-                
+
                 client = TestClient(app)
                 response = client.post(
                     "/v1/chat/completions",
@@ -168,7 +166,7 @@ class TestMainAPI:
                         "stream": False,
                     },
                 )
-                
+
                 assert response.status_code == 200
                 data = response.json()
                 assert "choices" in data
@@ -197,15 +195,13 @@ class TestMainAPI:
         async def mock_stream():
             yield b"data: chunk1\n\n"
             yield b"data: chunk2\n\n"
-        
+
         with patch("main.model_router") as mock_router:
-            with patch("main.FailoverRouter") as mock_failover_class:
+            with patch("main.failover_router") as mock_failover:
                 mock_router.get_free_models = AsyncMock(return_value=["model1"])
-                
-                mock_failover = MagicMock()
+
                 mock_failover.execute_with_failover = AsyncMock(return_value=mock_stream())
-                mock_failover_class.return_value = mock_failover
-                
+
                 client = TestClient(app)
                 response = client.post(
                     "/v1/chat/completions",
@@ -214,24 +210,22 @@ class TestMainAPI:
                         "stream": True,
                     },
                 )
-                
+
                 assert response.status_code == 200
                 assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
 
     def test_openai_compatibility(self):
         """OpenAI 互換のリクエスト形式を受け付ける"""
         with patch("main.model_router") as mock_router:
-            with patch("main.FailoverRouter") as mock_failover_class:
+            with patch("main.failover_router") as mock_failover:
                 mock_router.get_free_models = AsyncMock(return_value=["model1"])
-                
-                mock_failover = MagicMock()
+
                 mock_failover.execute_with_failover = AsyncMock(
                     return_value={"choices": [{"message": {"content": "response"}}]}
                 )
-                mock_failover_class.return_value = mock_failover
-                
+
                 client = TestClient(app)
-                
+
                 # OpenAI 互換のリクエスト
                 response = client.post(
                     "/v1/chat/completions",
@@ -245,7 +239,7 @@ class TestMainAPI:
                         "max_tokens": 100,
                     },
                 )
-                
+
                 assert response.status_code == 200
 
 


### PR DESCRIPTION
## 変更内容

### 主な変更
- **main.py**: FailoverRouter をグローバルに1回インスタンス化（リクエスト毎の再作成を回避）
- **main.py**: ログフォーマットから &#37;(name)s を削除し、シンプルに
- **router/failover.py**: ログ形式を  に統一

### 改善後ログ例


### その他
- **adapters**: ロガーインポート追加（今後の拡張用）
- **tests/test_main.py**: グローバルインスタンス化に伴うmock修正

## 確認事項
- [x] 全テスト通過 (66 passed)
- [x] 変更は最小差分に留める
- [x] Breaking Change なし