### PR TITLE
docs: English localization - separate Japanese docs to _jp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,68 @@
 # Free Model Router
 
-- OpenRouter の無料モデル + Ollama ローカルモデルを束ね、自動 Failover する OpenAI 互換プロキシサーバー。
-- まずはopenrouterのみです。
-- ollama使うでもcerebrasでもgeminiでも条件を合わせれば動くと思いますが、model取得APIが無い場合はスクレイピングの手間がありそうです。
+An OpenAI-compatible proxy server that automatically routes requests across OpenRouter's free models with failover support, falling back to a local Ollama model when all cloud models fail.
 
-## 特徴
+- Currently supports OpenRouter only.
+- Ollama, Cerebras, Gemini, and other providers should work if they expose an OpenAI-compatible API — though providers without a model list API may require additional scraping.
 
-- **OpenAI 互換 API** (`/v1/chat/completions`)
-- **動的モデルリスト取得** — OpenRouter の `:free` モデルを自動取得(実際はpriceをチェックして0のもの)
-- **優先順位ルーティング** — `qwen`, `nemotron` 等を優先
-- **自動リトライ (Failover)** — 429 / タイムアウト時に次モデルへ切替
-- **ローカル最終防衛線** — 全クラウドモデル失敗時は Ollama へフォールバック
-- **ストリーミング対応** — SSE 形式でリアルタイム応答
-- **ツール呼び出し自動検証** — 新規モデル検出時に function calling の可否を自動テストし、非対応モデルを自動除外
+## Features
 
-## ディレクトリ構造
+- **OpenAI-compatible API** (`/v1/chat/completions`)
+- **Dynamic model discovery** — Automatically fetches `:free` models from OpenRouter (actually checks pricing and selects models with cost = 0)
+- **Priority routing** — Prefers capable models like `qwen`, `nemotron`, etc.
+- **Auto failover** — Switches to the next model on 429 or timeout
+- **Local fallback** — Falls back to Ollama when all cloud models fail
+- **Streaming support** — Real-time responses via SSE
+- **Tool call verification** — Automatically tests function calling support on newly detected models and excludes incompatible ones
+
+## Directory Structure
 
 ```
-openrouter-routing/
-├── main.py                   # FastAPI サーバー本体
-├── config.json               # タイムアウト・優先度設定
-├── setup.sh                  # venv 作成・依存インストール・起動
-├── requirements.txt          # Python 依存パッケージ
-├── known_vendors.json        # 既知ベンダーリスト（自動更新）
+free-model-router/
+├── main.py                   # FastAPI server
+├── config.json               # Timeout and priority settings
+├── setup.sh                  # venv setup, dependency install, and server launch
+├── requirements.txt          # Python dependencies
+├── known_vendors.json        # Known vendor list (auto-updated)
 │
 ├── adapters/
 │   ├── __init__.py
-│   ├── base.py               # 抽象アダプター
-│   ├── openrouter.py         # OpenRouter 呼び出し
-│   └── ollama.py             # Ollama ローカル呼び出し
+│   ├── base.py               # Abstract adapter base
+│   ├── openrouter.py         # OpenRouter adapter
+│   └── ollama.py             # Ollama local adapter
 │
 ├── router/
 │   ├── __init__.py
-│   ├── model_router.py            # モデルリスト取得・優先順位付け
-│   ├── failover.py                # 429/タイムアウト検知・次モデルへ切替
-│   ├── tool_verifier.py           # モデルのツール呼び出し対応を検証
-│   └── tool_support_registry.py   # ツール対応モデルのキャッシュ管理
+│   ├── model_router.py            # Model list fetching and priority sorting
+│   ├── failover.py                # 429/timeout detection and model switching
+│   ├── tool_verifier.py           # Tests function calling support per model
+│   └── tool_support_registry.py   # Caches tool support results
 │
-├── tests/                    # テストファイル群
+├── tests/                    # Test files
 │
 └── docs/
-    └── how-it-works.md       # システム動作解説（アーキテクチャ・フロー図）
+    └── how-it-works.md       # Architecture and flow diagrams
 ```
 
-## セットアップ
+## Setup
 
-### 1. API キー設定
+### 1. Configure API Key
 
 ```bash
 cp .env.example .env
-# .env を編集して OPENROUTER_API_KEY を設定
+# Edit .env and set your OPENROUTER_API_KEY
 ```
 
-### 2. 起動
+### 2. Start the server
 
 ```bash
 ./setup.sh
 ```
 
-初回実行時は venv 作成・依存インストール後、`.env` が作成されます。  
-2回目以降は直接サーバーが起動します（デフォルト: `http://127.0.0.1:4141`）。
+On first run, this creates a virtual environment and installs dependencies.
+Subsequent runs start the server directly (default: `http://127.0.0.1:4141`).
 
-### 3. 動作確認
+### 3. Verify it's working
 
 ```bash
 curl -X POST http://127.0.0.1:4141/v1/chat/completions \
@@ -72,29 +73,27 @@ curl -X POST http://127.0.0.1:4141/v1/chat/completions \
   }'
 ```
 
-## 設定
+## Configuration
 
-`config.json` で以下を調整可能：
+All settings are in `config.json`:
 
-| 項目　　　　　　　　　　　　　| 説明　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　|
-| -------------------------------| -----------------------------------------------------------------------|
-| `timeout_seconds`　　　　　　 | 各モデルへのリクエストタイムアウト（秒）　　　　　　　　　　　　　　　|
-| `model_cache_ttl_seconds`　　 | モデルリストキャッシュ有効期限（秒）　　　　　　　　　　　　　　　　　|
-| `exclude_keywords`　　　　　　| 除外するモデルのキーワード（日本語に弱いモデル等）　　　　　　　　　　|
-| `priority_keywords`　　　　　 | モデル優先順位キーワード　　　　　　　　　　　　　　　　　　　　　　　|
-| `ollama_model`　　　　　　　　| ローカル Fallback モデル名　　　　　　　　　　　　　　　　　　　　　　|
-| `verify_tool_support`　　　　 | 起動時に新規モデルのツール呼び出し対応を検証する（デフォルト `true`） |
-| `verify_timeout_seconds`　　　| 検証リクエストのタイムアウト（秒）　　　　　　　　　　　　　　　　　　|
-| `tool_support_cache_file`　　 | 検証結果のキャッシュファイル名　　　　　　　　　　　　　　　　　　　　|
-| `rate_limit_cooldown_seconds` | 429 を返したモデルをスキップする秒数（デフォルト `60`、`0` で無効化） |
+| Key | Description |
+|-----|-------------|
+| `timeout_seconds` | Request timeout per model (seconds) |
+| `model_cache_ttl_seconds` | How long to cache the model list (seconds) |
+| `exclude_keywords` | Keywords to exclude models (e.g. models weak at your language) |
+| `priority_keywords` | Keywords for model priority ordering |
+| `ollama_model` | Local fallback model name |
+| `verify_tool_support` | Test function calling support on startup (default: `true`) |
+| `verify_timeout_seconds` | Timeout for verification requests (seconds) |
+| `tool_support_cache_file` | File name for caching verification results |
+| `rate_limit_cooldown_seconds` | Seconds to skip a model after a 429 (default: `60`, set `0` to disable) |
 
+## Tool Call Verification
 
-### ツール呼び出し検証の動作
-
-- 起動時、OpenRouter のモデルリスト中 **キャッシュに未記録のモデル** のみ検証します
-- 簡単な function calling リクエストを送り、`tool_calls` が返るかを確認します
-- 非対応と判定されたモデルは以降のリクエストから自動除外されます
-- 検証に失敗（429 / タイムアウト等）した場合は判定保留とし、次回起動時に再試行します
-- キャッシュファイル（`tool_support_cache.json`）は Git 管理外です
-
-
+- On startup, only models **not yet recorded in the cache** are verified
+- A simple function calling request is sent to check if `tool_calls` is returned
+- Models that fail verification are automatically excluded from routing
+- If verification fails due to 429 or timeout, the result is left pending and retried on next startup
+- The cache file (`tool_support_cache.json`) is excluded from Git
+ 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,98 @@
+# Free Model Router
+
+- OpenRouter の無料モデル + Ollama ローカルモデルを束ね、自動 Failover する OpenAI 互換プロキシサーバー。
+- まずはopenrouterのみです。
+- ollama使うでもcerebrasでもgeminiでも条件を合わせれば動くと思いますが、model取得APIが無い場合はスクレイピングの手間がありそうです。
+
+## 特徴
+
+- **OpenAI 互換 API** (`/v1/chat/completions`)
+- **動的モデルリスト取得** — OpenRouter の `:free` モデルを自動取得(実際はpriceをチェックして0のもの)
+- **優先順位ルーティング** — `qwen`, `nemotron` 等を優先
+- **自動リトライ (Failover)** — 429 / タイムアウト時に次モデルへ切替
+- **ローカル最終防衛線** — 全クラウドモデル失敗時は Ollama へフォールバック
+- **ストリーミング対応** — SSE 形式でリアルタイム応答
+- **ツール呼び出し自動検証** — 新規モデル検出時に function calling の可否を自動テストし、非対応モデルを自動除外
+
+## ディレクトリ構造
+
+```
+openrouter-routing/
+├── main.py                   # FastAPI サーバー本体
+├── config.json               # タイムアウト・優先度設定
+├── setup.sh                  # venv 作成・依存インストール・起動
+├── requirements.txt          # Python 依存パッケージ
+├── known_vendors.json        # 既知ベンダーリスト（自動更新）
+│
+├── adapters/
+│   ├── __init__.py
+│   ├── base.py               # 抽象アダプター
+│   ├── openrouter.py         # OpenRouter 呼び出し
+│   └── ollama.py             # Ollama ローカル呼び出し
+│
+├── router/
+│   ├── __init__.py
+│   ├── model_router.py            # モデルリスト取得・優先順位付け
+│   ├── failover.py                # 429/タイムアウト検知・次モデルへ切替
+│   ├── tool_verifier.py           # モデルのツール呼び出し対応を検証
+│   └── tool_support_registry.py   # ツール対応モデルのキャッシュ管理
+│
+├── tests/                    # テストファイル群
+│
+└── docs/
+    └── how-it-works.md       # システム動作解説（アーキテクチャ・フロー図）
+```
+
+## セットアップ
+
+### 1. API キー設定
+
+```bash
+cp .env.example .env
+# .env を編集して OPENROUTER_API_KEY を設定
+```
+
+### 2. 起動
+
+```bash
+./setup.sh
+```
+
+初回実行時は venv 作成・依存インストール後、`.env` が作成されます。  
+2回目以降は直接サーバーが起動します（デフォルト: `http://127.0.0.1:4141`）。
+
+### 3. 動作確認
+
+```bash
+curl -X POST http://127.0.0.1:4141/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "Hello"}],
+    "stream": false
+  }'
+```
+
+## 設定
+
+`config.json` で以下を調整可能：
+
+| 項目　　　　　　　　　　　　　| 説明　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　|
+| -------------------------------| -----------------------------------------------------------------------|
+| `timeout_seconds`　　　　　　 | 各モデルへのリクエストタイムアウト（秒）　　　　　　　　　　　　　　　|
+| `model_cache_ttl_seconds`　　 | モデルリストキャッシュ有効期限（秒）　　　　　　　　　　　　　　　　　|
+| `exclude_keywords`　　　　　　| 除外するモデルのキーワード（日本語に弱いモデル等）　　　　　　　　　　|
+| `priority_keywords`　　　　　 | モデル優先順位キーワード　　　　　　　　　　　　　　　　　　　　　　　|
+| `ollama_model`　　　　　　　　| ローカル Fallback モデル名　　　　　　　　　　　　　　　　　　　　　　|
+| `verify_tool_support`　　　　 | 起動時に新規モデルのツール呼び出し対応を検証する（デフォルト `true`） |
+| `verify_timeout_seconds`　　　| 検証リクエストのタイムアウト（秒）　　　　　　　　　　　　　　　　　　|
+| `tool_support_cache_file`　　 | 検証結果のキャッシュファイル名　　　　　　　　　　　　　　　　　　　　|
+| `rate_limit_cooldown_seconds` | 429 を返したモデルをスキップする秒数（デフォルト `60`、`0` で無効化） |
+
+
+### ツール呼び出し検証の動作
+
+- 起動時、OpenRouter のモデルリスト中 **キャッシュに未記録のモデル** のみ検証します
+- 簡単な function calling リクエストを送り、`tool_calls` が返るかを確認します
+- 非対応と判定されたモデルは以降のリクエストから自動除外されます
+- 検証に失敗（429 / タイムアウト等）した場合は判定保留とし、次回起動時に再試行します
+- キャッシュファイル（`tool_support_cache.json`）は Git 管理外です

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,12 +1,12 @@
-# システム動作解説
+# How It Works
 
-## 概要
+## Overview
 
-OpenRouter Routing Proxy は、複数の無料AIモデルを自動的に選択・フォールオーバーするプロキシサーバーです。
+Free Model Router is a proxy server that automatically selects and fails over across multiple free AI models.
 
-## 初回起動時の動作
+## Startup Behavior
 
-### モデルリスト取得フロー
+### Model List Fetch Flow
 
 ```mermaid
 sequenceDiagram
@@ -18,39 +18,39 @@ sequenceDiagram
 
     App->>MR: get_free_models()
     MR->>OR: GET /models
-    OR-->>MR: 全モデルリスト
-    MR->>MR: :free + pricing==0 で抽出
-    MR->>MR: exclude_keywords で除外
-    MR->>MR: priority_keywords でソート
-    MR-->>App: 優先順位付きFreeモデル
+    OR-->>MR: Full model list
+    MR->>MR: Filter by :free + pricing==0
+    MR->>MR: Exclude by exclude_keywords
+    MR->>MR: Sort by priority_keywords
+    MR-->>App: Prioritized free model list
 
     App->>TSR: prune(models)
-    TSR->>Cache: 存在しないモデルを削除
+    TSR->>Cache: Remove models no longer available
 
     App->>TSR: get_unverified(models)
-    TSR-->>App: 未検証モデル一覧
+    TSR-->>App: List of unverified models
 
-    loop 各未検証モデル
-        App->>OR: ツール対応テスト
-        OR-->>App: 結果
+    loop For each unverified model
+        App->>OR: Tool support test
+        OR-->>App: Result
         App->>TSR: mark(model, result)
     end
-    TSR->>Cache: 保存
+    TSR->>Cache: Save
 ```
 
-### 処理の詳細
+### Step-by-Step
 
-1. **モデル取得**: OpenRouterから全モデルを取得
-2. **Free抽出**: `:free` suffix + pricingが0のモデルを抽出
-3. **除外**: `exclude_keywords`（dolphin, liquid, arcee等）に該当するモデルを除外
-4. **ソート**: `priority_keywords` のpriority値でソート（小さいほど優先）
-5. **ツール検証**: 未検証モデルのツール対応をテストし永続キャッシュ
+1. **Fetch models**: Retrieve the full model list from OpenRouter
+2. **Filter free models**: Select models with `:free` suffix and pricing == 0
+3. **Exclude**: Remove models matching `exclude_keywords` (e.g. dolphin, liquid, arcee)
+4. **Sort**: Order by `priority_keywords` priority value (lower = higher priority)
+5. **Verify tools**: Test function calling support on unverified models and cache results
 
 ---
 
-## リクエスト時の動作
+## Request Handling
 
-### チャット補完リクエスト
+### Chat Completion Request
 
 ```mermaid
 sequenceDiagram
@@ -65,39 +65,39 @@ sequenceDiagram
     Client->>App: POST /v1/chat/completions
 
     App->>MR: get_free_models()
-    MR->>MR: メモリキャッシュ確認（TTL: 300秒）
-    MR-->>App: モデルリスト
+    MR->>MR: Check memory cache (TTL: 300s)
+    MR-->>App: Model list
 
     App->>TSR: filter_supported(models)
-    TSR-->>App: ツール対応モデルのみ
+    TSR-->>App: Tool-compatible models only
 
-    loop モデル順に試行
+    loop Try models in priority order
         App->>FR: execute_with_failover()
-        FR->>FR: クールダウン中を除外
+        FR->>FR: Skip models in cooldown
 
-        FR->>OR: chat_completion(model=1位)
+        FR->>OR: chat_completion(model=1st)
         alt 200 OK
-            OR-->>FR: 成功レスポンス
-            FR-->>App: 結果
-            App-->>Client: 応答
+            OR-->>FR: Success response
+            FR-->>App: Result
+            App-->>Client: Response
         else 429 Rate Limit
             OR-->>FR: 429
-            FR->>FR: COOLDOWN 120s設定
-            FR->>FR: 次のモデルへ
+            FR->>FR: Set COOLDOWN 120s
+            FR->>FR: Try next model
         else Timeout
-            FR->>FR: 次のモデルへ
+            FR->>FR: Try next model
         end
     end
 
-    alt 全モデル失敗
+    alt All models failed
         FR->>Ollama: chat_completion(local)
-        Ollama-->>FR: 結果
-        FR-->>App: 結果
-        App-->>Client: 応答
+        Ollama-->>FR: Result
+        FR-->>App: Result
+        App-->>Client: Response
     end
 ```
 
-### ストリーミングリクエスト
+### Streaming Request
 
 ```mermaid
 sequenceDiagram
@@ -108,34 +108,34 @@ sequenceDiagram
 
     Client->>App: POST /v1/chat/completions (stream=true)
 
-    loop 各モデル
+    loop Each model
         FR->>OR: chat_completion_stream()
-        alt 成功
-            OR-->>Client: チャンク逐次返却
-            OR-->>FR: 完了
-            FR-->>App: 終了
+        alt Success
+            OR-->>Client: Stream chunks
+            OR-->>FR: Done
+            FR-->>App: Exit
         else 429/Timeout
-            FR->>FR: 次のモデルへフォールオーバー
+            FR->>FR: Failover to next model
         end
     end
 ```
 
 ---
 
-## キャッシュ機構
+## Cache Summary
 
-| キャッシュ　　　 | 場所　　　　　　　　　　　　　 | 内容　　　　　　　　 | TTL/永続性　　　　　　　　　　 |
-| ------------------| --------------------------------| ----------------------| --------------------------------|
-| **モデルリスト** | メモリ (`_cached_models`)　　　| Freeモデル一覧　　　 | 300秒　　　　　　　　　　　　　|
-| **ツール対応**　 | `tool_support_cache.json`　　　| モデルごとの対応有無 | 永続　　　　　　　　　　　　　 |
-| **クールダウン** | クラス変数 (`_cooldown_until`) | 429モデルの休止状態　| プロセス内（再起動でリセット） |
-| **既知ベンダー** | `known_vendors.json`　　　　　 | 通知済みベンダー一覧 | 永続　　　　　　　　　　　　　 |
+| Cache | Location | Content | TTL / Persistence |
+|-------|----------|---------|-------------------|
+| **Model list** | Memory (`_cached_models`) | Free model list | 300 seconds |
+| **Tool support** | `tool_support_cache.json` | Per-model tool support flag | Persistent |
+| **Cooldown** | Class variable (`_cooldown_until`) | Rate-limited model state | In-process (reset on restart) |
+| **Known vendors** | `known_vendors.json` | List of notified vendors | Persistent |
 
 ---
 
-## フォールオーバーの動作例
+## Failover Example
 
-実際のログと対応する動作：
+Actual log output and corresponding behavior:
 
 ```
 2026-04-29 00:13:38,349 [WARNING] 429 Rate limit   qwen/qwen3-next-80b-a3b-instruct:free
@@ -149,17 +149,17 @@ sequenceDiagram
     participant qwen as qwen/...
     participant glm as glm/...
 
-    FR->>qwen: リクエスト
+    FR->>qwen: Request
     qwen-->>FR: 429 Rate Limit
-    FR->>FR: COOLDOWN 120s設定
-    FR->>glm: リクエスト
+    FR->>FR: Set COOLDOWN 120s
+    FR->>glm: Request
     glm-->>FR: 200 OK
-    FR-->>FR: 応答返却
+    FR-->>FR: Return response
 ```
 
 ---
 
-## 設定ファイル (`config.json`)
+## Configuration (`config.json`)
 
 ```json
 {
@@ -174,17 +174,15 @@ sequenceDiagram
 }
 ```
 
-### キー設定の説明
-
-- **`exclude_keywords`**: 除外するモデル名のキーワード
-- **`priority_keywords`**: 優先順位付けルール（priority値が小さいほど先頭）
-- **`rate_limit_cooldown_seconds`**: 429発生時の休止時間（秒）
+- **`exclude_keywords`**: Model name keywords to exclude from routing
+- **`priority_keywords`**: Priority rules — lower value = higher priority
+- **`rate_limit_cooldown_seconds`**: How long to skip a model after a 429
 
 ---
 
-## まとめ
+## Summary
 
-1. **起動時**: Freeモデルを取得・整列・ツール検証
-2. **リクエスト時**: 上位モデルから順に試行、429は自動休止
-3. **フォールバック**: 全モデル失敗時はローカルOllamaへ
-4. **クールダウン**: 429モデルを120秒間自動スキップ
+1. **Startup**: Fetch free models, sort by priority, verify tool support
+2. **Per request**: Try models in order, auto-skip on 429
+3. **Fallback**: Route to local Ollama when all cloud models fail
+4. **Cooldown**: Automatically skip rate-limited models for 120 seconds

--- a/docs/how-it-works_jp.md
+++ b/docs/how-it-works_jp.md
@@ -1,0 +1,190 @@
+# システム動作解説
+
+## 概要
+
+OpenRouter Routing Proxy は、複数の無料AIモデルを自動的に選択・フォールオーバーするプロキシサーバーです。
+
+## 初回起動時の動作
+
+### モデルリスト取得フロー
+
+```mermaid
+sequenceDiagram
+    participant App as FastAPI App
+    participant MR as ModelRouter
+    participant OR as OpenRouter API
+    participant TSR as ToolSupportRegistry
+    participant Cache as tool_support_cache.json
+
+    App->>MR: get_free_models()
+    MR->>OR: GET /models
+    OR-->>MR: 全モデルリスト
+    MR->>MR: :free + pricing==0 で抽出
+    MR->>MR: exclude_keywords で除外
+    MR->>MR: priority_keywords でソート
+    MR-->>App: 優先順位付きFreeモデル
+
+    App->>TSR: prune(models)
+    TSR->>Cache: 存在しないモデルを削除
+
+    App->>TSR: get_unverified(models)
+    TSR-->>App: 未検証モデル一覧
+
+    loop 各未検証モデル
+        App->>OR: ツール対応テスト
+        OR-->>App: 結果
+        App->>TSR: mark(model, result)
+    end
+    TSR->>Cache: 保存
+```
+
+### 処理の詳細
+
+1. **モデル取得**: OpenRouterから全モデルを取得
+2. **Free抽出**: `:free` suffix + pricingが0のモデルを抽出
+3. **除外**: `exclude_keywords`（dolphin, liquid, arcee等）に該当するモデルを除外
+4. **ソート**: `priority_keywords` のpriority値でソート（小さいほど優先）
+5. **ツール検証**: 未検証モデルのツール対応をテストし永続キャッシュ
+
+---
+
+## リクエスト時の動作
+
+### チャット補完リクエスト
+
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant App as FastAPI App
+    participant MR as ModelRouter
+    participant TSR as ToolSupportRegistry
+    participant FR as FailoverRouter
+    participant OR as OpenRouter
+    participant Ollama as Ollama Local
+
+    Client->>App: POST /v1/chat/completions
+
+    App->>MR: get_free_models()
+    MR->>MR: メモリキャッシュ確認（TTL: 300秒）
+    MR-->>App: モデルリスト
+
+    App->>TSR: filter_supported(models)
+    TSR-->>App: ツール対応モデルのみ
+
+    loop モデル順に試行
+        App->>FR: execute_with_failover()
+        FR->>FR: クールダウン中を除外
+
+        FR->>OR: chat_completion(model=1位)
+        alt 200 OK
+            OR-->>FR: 成功レスポンス
+            FR-->>App: 結果
+            App-->>Client: 応答
+        else 429 Rate Limit
+            OR-->>FR: 429
+            FR->>FR: COOLDOWN 120s設定
+            FR->>FR: 次のモデルへ
+        else Timeout
+            FR->>FR: 次のモデルへ
+        end
+    end
+
+    alt 全モデル失敗
+        FR->>Ollama: chat_completion(local)
+        Ollama-->>FR: 結果
+        FR-->>App: 結果
+        App-->>Client: 応答
+    end
+```
+
+### ストリーミングリクエスト
+
+```mermaid
+sequenceDiagram
+    participant Client as Client
+    participant App as FastAPI App
+    participant FR as FailoverRouter
+    participant OR as OpenRouter
+
+    Client->>App: POST /v1/chat/completions (stream=true)
+
+    loop 各モデル
+        FR->>OR: chat_completion_stream()
+        alt 成功
+            OR-->>Client: チャンク逐次返却
+            OR-->>FR: 完了
+            FR-->>App: 終了
+        else 429/Timeout
+            FR->>FR: 次のモデルへフォールオーバー
+        end
+    end
+```
+
+---
+
+## キャッシュ機構
+
+| キャッシュ　　　 | 場所　　　　　　　　　　　　　 | 内容　　　　　　　　 | TTL/永続性　　　　　　　　　　 |
+| ------------------| --------------------------------| ----------------------| --------------------------------|
+| **モデルリスト** | メモリ (`_cached_models`)　　　| Freeモデル一覧　　　 | 300秒　　　　　　　　　　　　　|
+| **ツール対応**　 | `tool_support_cache.json`　　　| モデルごとの対応有無 | 永続　　　　　　　　　　　　　 |
+| **クールダウン** | クラス変数 (`_cooldown_until`) | 429モデルの休止状態　| プロセス内（再起動でリセット） |
+| **既知ベンダー** | `known_vendors.json`　　　　　 | 通知済みベンダー一覧 | 永続　　　　　　　　　　　　　 |
+
+---
+
+## フォールオーバーの動作例
+
+実際のログと対応する動作：
+
+```
+2026-04-29 00:13:38,349 [WARNING] 429 Rate limit   qwen/qwen3-next-80b-a3b-instruct:free
+2026-04-29 00:13:38,349 [INFO] COOLDOWN 120s   qwen/qwen3-next-80b-a3b-instruct:free
+2026-04-29 00:13:50,310 [INFO] 200 OK (stream)   z-ai/glm-4.5-air:free
+```
+
+```mermaid
+sequenceDiagram
+    participant FR as FailoverRouter
+    participant qwen as qwen/...
+    participant glm as glm/...
+
+    FR->>qwen: リクエスト
+    qwen-->>FR: 429 Rate Limit
+    FR->>FR: COOLDOWN 120s設定
+    FR->>glm: リクエスト
+    glm-->>FR: 200 OK
+    FR-->>FR: 応答返却
+```
+
+---
+
+## 設定ファイル (`config.json`)
+
+```json
+{
+  "timeout_seconds": 15,
+  "model_cache_ttl_seconds": 300,
+  "exclude_keywords": [ "dolphin", "liquid", "arcee" ],
+  "priority_keywords": [
+    { "keywords": [ "next", "80b", "air" ], "priority": 1 },
+    { "keywords": [ "nano", "mini", "lite", "flash" ], "priority": 98 }
+  ],
+  "rate_limit_cooldown_seconds": 120
+}
+```
+
+### キー設定の説明
+
+- **`exclude_keywords`**: 除外するモデル名のキーワード
+- **`priority_keywords`**: 優先順位付けルール（priority値が小さいほど先頭）
+- **`rate_limit_cooldown_seconds`**: 429発生時の休止時間（秒）
+
+---
+
+## まとめ
+
+1. **起動時**: Freeモデルを取得・整列・ツール検証
+2. **リクエスト時**: 上位モデルから順に試行、429は自動休止
+3. **フォールバック**: 全モデル失敗時はローカルOllamaへ
+4. **クールダウン**: 429モデルを120秒間自動スキップ


### PR DESCRIPTION
## 概要
 
英語版ドキュメントを主に設定し、日本語版は `_ja.md` / `_jp.md` サフィックスのファイルに分離しました。
 
## 変更内容
 
- 変更
  - README.md
  - docs/how-it-works.md
- 追加
  - README_ja.md
  - docs/how-it-works_jp.md
 
## テスト
 
- コード変更なし（ドキュメントのみ）
- 既存のテストに影響なし
 
## 備考
