### PR TITLE
feat: 404エラー時に600秒クールダウンを追加 (#35)

### DIFF
--- a/adapters/base.py
+++ b/adapters/base.py
@@ -10,6 +10,10 @@ class ProviderTimeoutError(Exception):
     """タイムアウトエラー"""
 
 
+class NotFoundError(Exception):
+    """404 Not Found エラー"""
+
+
 class ProviderError(Exception):
     """その他のプロバイダーエラー"""
 

--- a/adapters/openrouter.py
+++ b/adapters/openrouter.py
@@ -4,7 +4,7 @@ from typing import AsyncGenerator
 
 import httpx
 
-from .base import AbstractLLMAdapter, ProviderError, ProviderTimeoutError, RateLimitError
+from .base import AbstractLLMAdapter, NotFoundError, ProviderError, ProviderTimeoutError, RateLimitError
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,8 @@ class OpenRouterAdapter(AbstractLLMAdapter):
 
         if resp.status_code == 429:
             raise RateLimitError(f"OpenRouter 429 ({model})")
+        if resp.status_code == 404:
+            raise NotFoundError(f"OpenRouter 404 ({model})")
         if not resp.is_success:
             raise ProviderError(f"OpenRouter {resp.status_code} ({model}): {resp.text[:200]}")
 
@@ -70,6 +72,9 @@ class OpenRouterAdapter(AbstractLLMAdapter):
             if resp.status_code == 429:
                 await resp.aclose()
                 raise RateLimitError(f"OpenRouter 429 ({model})")
+            if resp.status_code == 404:
+                await resp.aclose()
+                raise NotFoundError(f"OpenRouter 404 ({model})")
             if not resp.is_success:
                 err = await resp.aread()
                 raise ProviderError(f"OpenRouter {resp.status_code} ({model}): {err[:200]}")

--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
   "verify_timeout_seconds": 15,
   "tool_support_cache_file": "tool_support_cache.json",
   "rate_limit_cooldown_seconds": 120,
+  "not_found_cooldown_seconds": 600,
   "exclude_keywords": [ "dolphin", "liquid", "arcee" ],
   "priority_keywords": [
     { "keywords": [ "next", "80b", "air" ], "priority": 1 },

--- a/main.py
+++ b/main.py
@@ -49,6 +49,7 @@ failover_router = FailoverRouter(
     local_model=config["ollama_model"],
     timeout=config["timeout_seconds"],
     cooldown_seconds=float(config.get("rate_limit_cooldown_seconds", 60)),
+    not_found_cooldown_seconds=float(config.get("not_found_cooldown_seconds", 600)),
 )
 
 tool_support_registry = ToolSupportRegistry(

--- a/router/failover.py
+++ b/router/failover.py
@@ -4,6 +4,7 @@ from typing import AsyncIterator
 
 from adapters.base import (
     AbstractLLMAdapter,
+    NotFoundError,
     ProviderError,
     ProviderTimeoutError,
     RateLimitError,
@@ -27,12 +28,14 @@ class FailoverRouter:
         local_model: str,
         timeout: float,
         cooldown_seconds: float = 60.0,
+        not_found_cooldown_seconds: float = 600.0,
     ) -> None:
         self._cloud_adapter = cloud_adapter
         self._local_adapter = local_adapter
         self._local_model = local_model
         self._timeout = timeout
         self._cooldown_seconds = cooldown_seconds
+        self._not_found_cooldown_seconds = not_found_cooldown_seconds
 
     def _is_cooling_down(self, model: str) -> bool:
         """モデルがクールダウン期間中かを判定"""
@@ -45,12 +48,14 @@ class FailoverRouter:
             return False
         return True
 
-    def _mark_cooldown(self, model: str) -> None:
-        """モデルを cooldown_seconds 秒間スキップ対象にする"""
-        if self._cooldown_seconds <= 0:
+    def _mark_cooldown(self, model: str, duration: float | None = None) -> None:
+        """モデルを指定秒数間スキップ対象にする"""
+        if duration is None:
+            duration = self._cooldown_seconds
+        if duration <= 0:
             return
-        self._cooldown_until[model] = time.monotonic() + self._cooldown_seconds
-        logger.info(f"COOLDOWN {self._cooldown_seconds:.0f}s   {model}")
+        self._cooldown_until[model] = time.monotonic() + duration
+        logger.info(f"COOLDOWN {duration:.0f}s   {model}")
 
     def _filter_available(self, models: list[str]) -> list[str]:
         """クールダウン中のモデルを除外"""
@@ -89,6 +94,11 @@ class FailoverRouter:
             except RateLimitError as exc:
                 logger.warning(f"429 Rate limit   {model}")
                 self._mark_cooldown(model)
+                last_error = exc
+                continue
+            except NotFoundError as exc:
+                logger.warning(f"404 Not Found   {model}")
+                self._mark_cooldown(model, self._not_found_cooldown_seconds)
                 last_error = exc
                 continue
             except ProviderTimeoutError as exc:
@@ -132,6 +142,11 @@ class FailoverRouter:
             except RateLimitError as exc:
                 logger.warning(f"429 Rate limit   {model}")
                 self._mark_cooldown(model)
+                last_error = exc
+                continue
+            except NotFoundError as exc:
+                logger.warning(f"404 Not Found   {model}")
+                self._mark_cooldown(model, self._not_found_cooldown_seconds)
                 last_error = exc
                 continue
             except ProviderTimeoutError as exc:


### PR DESCRIPTION
## 概要
Issue #35: Long cooldown for "ghost" models (404 responses)

## 変更内容
- NotFoundError例外クラスを追加
- OpenRouterアダプターで404検出時にNotFoundErrorを発生
- config.jsonにnot_found_cooldown_seconds設定を追加 (デフォルト: 600秒)
- FailoverRouterでNotFoundErrorを600秒クールダウンで処理
- メモリキャッシュで「ghost models」を一時的に除外

## 動作
- 404エラー発生時: 600秒間そのモデルをスキップ
- 429エラー: 従来通り120秒クールダウン
- 設定可能: config.jsonのnot_found_cooldown_secondsで調整可能