### PR TITLE
fix: NotFoundError発生時にツール非対応として記録

### DIFF
--- a/router/tool_verifier.py
+++ b/router/tool_verifier.py
@@ -8,6 +8,7 @@ import logging
 
 from adapters.base import (
     AbstractLLMAdapter,
+    NotFoundError,
     ProviderError,
     ProviderTimeoutError,
     RateLimitError,
@@ -74,6 +75,9 @@ async def verify_tool_support(
     except (RateLimitError, ProviderTimeoutError) as exc:
         logger.info(f"Tool support verify deferred for {model}: {exc}")
         return None
+    except NotFoundError as exc:
+        logger.info(f"Model not found, marking as unsupported: {model}")
+        return False
     except ProviderError as exc:
         message = str(exc)
         if any(marker in message for marker in _NO_TOOL_SUPPORT_MARKERS):

--- a/tests/test_tool_verifier.py
+++ b/tests/test_tool_verifier.py
@@ -8,7 +8,7 @@ for mod in list(sys.modules.keys()):
     if mod.startswith("adapters.") or mod.startswith("router."):
         del sys.modules[mod]
 
-from adapters.base import ProviderError, ProviderTimeoutError, RateLimitError
+from adapters.base import NotFoundError, ProviderError, ProviderTimeoutError, RateLimitError
 from router.tool_verifier import verify_tool_support
 
 
@@ -87,6 +87,13 @@ class TestVerifyToolSupport:
         adapter = _FakeAdapter(exc=ProviderError("500"))
         result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_not_found_error(self):
+        """404 NotFoundError が発生した場合は非対応として扱う"""
+        adapter = _FakeAdapter(exc=NotFoundError("OpenRouter 404 (x/y:free)"))
+        result = await verify_tool_support(adapter, "x/y:free", timeout=5.0)
+        assert result is False
 
     @pytest.mark.asyncio
     async def test_returns_false_on_explicit_no_tool_support_error(self):


### PR DESCRIPTION
## 概要
Issue #34 の修正: OpenRouterのツール非対応モデルが毎回404エラーで再検証される問題を解決

## 問題
- `tool_verifier.py`で`NotFoundError`(404)が適切に処理されていなかった
- 404が発生すると判定保留(`None`)となり、キャッシュに記録されない
- 次回起動時にまた404リクエストを送る無駄が発生

## 変更内容
- `router/tool_verifier.py`: `NotFoundError`を捕捉し、`False`(非対応)を返すように修正
- `tests/test_tool_verifier.py`: `NotFoundError`のテストケースを追加

- **修正前**: 404エラー → 判定保留 → 次回起動時に再検証 → 無駄な404リクエスト
- **修正後**: 404エラー → 非対応として記録 → 次回以降スキップ ✅

## テスト
- 起動して動作確認済

Fixes #34
